### PR TITLE
Serve visualiser from root index

### DIFF
--- a/docs/assumptions.md
+++ b/docs/assumptions.md
@@ -1,0 +1,74 @@
+# Solver assumptions and conventions
+
+## Coordinate system
+
+* The still water surface is the global origin in the vertical direction: `y = 0` at the surface and `y = waterDepth` at the seabed. Positive `y` points downward.
+* The fairlead is located at depth `fairleadDepth` below the surface. Internal integration coordinates start at the fairlead, so the suspended-line ordinate that the solver integrates (`y_local`) is zero at the fairlead and increases downward. The absolute depth of any point along the line is therefore `y_abs = fairleadDepth + y_local`.
+* Horizontal distance `x` is measured from the fairlead toward the anchor. The touchdown point is the first location where `y_abs` reaches the seabed (`waterDepth`).
+
+## Governing equations
+
+* Arc-length (`s`) is used as the marching coordinate. The state variable `u` is the standard catenary parameter, so that the differential system is
+  * `dy/ds = tanh(u)`
+  * `du/ds = + w / (H * cosh(u))`
+  * `dx/ds = 1 / cosh(u)`
+  where `w` is the submerged weight per unit length for the current segment and `H` is the horizontal component of the tension. These equations are integrated with a fourth-order Runge–Kutta scheme with an adaptive step cap at segment and buoy boundaries.
+
+## Segments and buoy handling
+
+* The line is assembled as two in-line segments in this order: wire first, chain second. Segment-specific weight (`w`) and seabed friction (`μ`) properties switch instantaneously at their arc-length boundaries.
+* Buoys (if any) are defined by their along-line attachment (`arcLength`), upward force (`force`), and pennant length. When the integration arrives at the buoy location the vertical component of tension is reduced by the applied buoyancy, clamped to non-negative values:
+  * `V_above = max(0, V_below − F_buoy)`
+  * The vertical drop is only applied when the pennant is taut. The pennant is considered taut when the attached point on the line is deeper than the pennant length below the buoy. The buoy is drawn at depth `y_abs = fairleadDepth + (attachDepth − pennantLength)` but never above the surface.
+
+## Touchdown and grounded allocation
+
+* Touchdown is detected when the absolute depth equals the seabed depth: `fairleadDepth + y_local = waterDepth`. The integration stops at the touchdown point when solving for the final geometry.
+* Any remaining length after touchdown is placed on the seabed. Grounded length is allocated to the chain segment first; if additional length remains it is assigned to the wire segment.
+* Seabed friction is only applied on grounded portions. The horizontal tension that arrives at the anchor is computed as `H_anchor = max(0, H_touchdown − Σ μ_i w_i L_grounded_i)`.
+
+## Tension modes
+
+* **T-mode** (`mode: "T"`): the total fairlead tension magnitude is prescribed. The solver brackets and bisects the horizontal component `H` so that, if the line were fully suspended, the total vertical drop equals the water depth. This guarantees the longest fairlead-to-touchdown span that is compatible with the prescribed total tension.
+* **H-mode** (`mode: "H"`): the fairlead horizontal tension component is prescribed. The solver brackets and bisects the initial catenary parameter `u₀` to reach the same limiting geometry (the suspended solution reaches the seabed exactly at the end of the full length).
+* The vertical component at the fairlead is determined from `u₀` by `V₀ = H sinh(u₀)`; the total fairlead tension is `T = H cosh(u₀)`.
+
+## API contract
+
+The physics solver is exposed via `solve(config)` from `src/solver.js`. The configuration object must contain:
+
+```jsonc
+{
+  "waterDepth": number,          // metres, > fairleadDepth
+  "fairleadDepth": number,       // metres below surface
+  "wire": { "length": number, "weight": number, "friction": number },
+  "chain": { "length": number, "weight": number, "friction": number },
+  "buoys": [
+    {
+      "arcLength": number,       // metres along the line from the fairlead
+      "force": number,           // upward force
+      "pennantLength": number    // slack length, metres
+    }
+  ],
+  "tensionCases": [
+    {
+      "id": string,
+      "mode": "T" | "H",
+      "value": number            // total tension (T-mode) or horizontal component (H-mode)
+    }
+  ]
+}
+```
+
+The return value is `{ results, warnings, context }`, where each entry in `results` has
+
+* `id`, `mode`, and the input value for traceability
+* `touchdown` `{ s, x, y }` (arc-length, horizontal reach, and local depth at touchdown)
+* `grounded` and `suspended` lengths for wire and chain
+* `anchorDistance` (fairlead-to-anchor horizontal distance)
+* `H_anchor` (horizontal tension that reaches the anchor)
+* `geometry` (arrays of points for suspended and grounded portions)
+* `buoyStates` (taut/slack status and drawing data)
+* `warnings` (e.g. "dragging risk" when the anchor tension decays to zero with grounded length present)
+
+The solver raises an error when both the wire and chain have zero length (`"No suspended line; anchor dragging risk."`) and when the prescribed tension cannot deliver a seabed touchdown.

--- a/docs/assumptions.md
+++ b/docs/assumptions.md
@@ -29,7 +29,7 @@
 
 ## Tension modes
 
-* **T-mode** (`mode: "T"`): the total fairlead tension magnitude is prescribed. The solver brackets and bisects the horizontal component `H` so that, if the line were fully suspended, the total vertical drop equals the water depth. This guarantees the longest fairlead-to-touchdown span that is compatible with the prescribed total tension.
+* **T-mode** (`mode: "T"`): the total fairlead tension magnitude is prescribed. The solver brackets and bisects the fairlead catenary parameter `u₀`; each trial uses `H = T / cosh(u₀)` so the prescribed total tension is honoured while searching for a suspended profile that just reaches the seabed. This guarantees the longest fairlead-to-touchdown span that is compatible with the prescribed total tension.
 * **H-mode** (`mode: "H"`): the fairlead horizontal tension component is prescribed. The solver brackets and bisects the initial catenary parameter `u₀` to reach the same limiting geometry (the suspended solution reaches the seabed exactly at the end of the full length).
 * The vertical component at the fairlead is determined from `u₀` by `V₀ = H sinh(u₀)`; the total fairlead tension is `T = H cosh(u₀)`.
 
@@ -69,6 +69,6 @@ The return value is `{ results, warnings, context }`, where each entry in `resul
 * `H_anchor` (horizontal tension that reaches the anchor)
 * `geometry` (arrays of points for suspended and grounded portions)
 * `buoyStates` (taut/slack status and drawing data)
-* `warnings` (e.g. "dragging risk" when the anchor tension decays to zero with grounded length present)
+* `warnings` (e.g. "dragging risk" when the anchor tension decays to zero with grounded length present, "No grounded length: anchor-drag risk" when the suspended solution consumes the entire line)
 
 The solver raises an error when both the wire and chain have zero length (`"No suspended line; anchor dragging risk."`) and when the prescribed tension cannot deliver a seabed touchdown.

--- a/docs/assumptions.md
+++ b/docs/assumptions.md
@@ -17,7 +17,7 @@
 ## Segments and buoy handling
 
 * The line is assembled as two in-line segments in this order: wire first, chain second. Segment-specific weight (`w`) and seabed friction (`μ`) properties switch instantaneously at their arc-length boundaries.
-* Buoys (if any) are defined by their along-line attachment (`arcLength`), upward force (`force`), and pennant length. When the integration arrives at the buoy location the vertical component of tension is reduced by the applied buoyancy, clamped to non-negative values:
+* Buoys (if any) are defined by their along-line attachment (`arcLength` measured from the anchor toward the fairlead), upward force (`force`), and pennant length. When the integration arrives at the buoy location the vertical component of tension is reduced by the applied buoyancy, clamped to non-negative values:
   * `V_above = max(0, V_below − F_buoy)`
   * The vertical drop is only applied when the pennant is taut. The pennant is considered taut when the attached point on the line is deeper than the pennant length below the buoy. The buoy is drawn at depth `y_abs = fairleadDepth + (attachDepth − pennantLength)` but never above the surface.
 
@@ -45,7 +45,7 @@ The physics solver is exposed via `solve(config)` from `src/solver.js`. The conf
   "chain": { "length": number, "weight": number, "friction": number },
   "buoys": [
     {
-      "arcLength": number,       // metres along the line from the fairlead
+      "arcLength": number,       // metres along the line from the anchor
       "force": number,           // upward force
       "pennantLength": number    // slack length, metres
     }

--- a/index.html
+++ b/index.html
@@ -54,7 +54,9 @@
       font-size: 0.95rem;
       color: #cbd5f5;
     }
-    select {
+    select,
+    input,
+    button {
       width: 100%;
       padding: 0.6rem 0.75rem;
       border-radius: 12px;
@@ -65,9 +67,64 @@
       outline: none;
       transition: border 0.2s ease;
     }
-    select:focus {
+    select:focus,
+    input:focus,
+    button:focus {
       border-color: #38bdf8;
       box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.35);
+    }
+    button {
+      margin-top: 0.5rem;
+      font-weight: 600;
+      cursor: pointer;
+      color: #0f172a;
+      background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+      border: none;
+      box-shadow: 0 10px 25px rgba(14, 165, 233, 0.35);
+      transition: transform 0.15s ease, box-shadow 0.15s ease;
+    }
+    button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 28px rgba(14, 165, 233, 0.45);
+    }
+    fieldset {
+      border: 1px solid rgba(148, 163, 184, 0.3);
+      border-radius: 12px;
+      padding: 0.75rem 0.9rem 0.85rem;
+      margin: 0 0 1rem;
+    }
+    fieldset legend {
+      padding: 0 0.35rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      font-size: 0.75rem;
+      color: #94a3b8;
+    }
+    .inline {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.75rem;
+    }
+    .buoy-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 0.5rem;
+      margin-bottom: 0.75rem;
+    }
+    .buoy-grid label {
+      margin-bottom: 0;
+    }
+    .buoy-block {
+      border: 1px dashed rgba(148, 163, 184, 0.3);
+      border-radius: 10px;
+      padding: 0.6rem 0.7rem;
+      margin-bottom: 0.75rem;
+    }
+    .buoy-title {
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: #facc15;
+      margin-bottom: 0.35rem;
     }
     #plot-wrapper {
       position: relative;
@@ -149,7 +206,66 @@
         Select tension
         <select id="tension-select"></select>
       </label>
-      <div id="scenario-info"></div>
+      <form id="input-form">
+        <fieldset>
+          <legend>Environment</legend>
+          <label>
+            Water depth WD (m)
+            <input type="number" step="0.01" id="water-depth" required />
+          </label>
+          <label>
+            Fairlead height df (m) (negative = above water)
+            <input type="number" step="0.01" id="fairlead-depth" required />
+          </label>
+          <label>
+            Total line length incl chain (m)
+            <input type="number" step="0.01" id="total-length" required />
+          </label>
+          <label>
+            Overlay tensions (t, comma-separated)
+            <input type="text" id="tension-list" placeholder="e.g. T650, H320" />
+          </label>
+        </fieldset>
+        <fieldset>
+          <legend>Wire (from fairlead)</legend>
+          <div class="inline">
+            <label>
+              Weight w_wire (kgf/m)
+              <input type="number" step="0.0001" id="wire-weight" required />
+            </label>
+            <label>
+              Friction μ_wire
+              <input type="number" step="0.0001" id="wire-friction" min="0" />
+            </label>
+          </div>
+        </fieldset>
+        <fieldset>
+          <legend>Chain (at anchor)</legend>
+          <div class="inline">
+            <label>
+              Chain length L_chain (m)
+              <input type="number" step="0.01" id="chain-length" required />
+            </label>
+            <label>
+              Weight w_chain (kgf/m)
+              <input type="number" step="0.0001" id="chain-weight" required />
+            </label>
+          </div>
+          <label>
+            Friction μ_chain
+            <input type="number" step="0.0001" id="chain-friction" min="0" />
+          </label>
+        </fieldset>
+        <fieldset>
+          <legend>Buoys</legend>
+          <label>
+            Number of buoys
+            <input type="number" id="buoy-count" min="0" step="1" value="0" />
+          </label>
+          <div id="buoy-inputs"></div>
+        </fieldset>
+        <button type="submit">Solve configuration</button>
+      </form>
       <div class="legend">
         <span><i style="background:#38bdf8;"></i>Suspended line</span>
         <span><i style="background:#f97316;"></i>Grounded on seabed</span>
@@ -189,12 +305,26 @@
     const tensionSelect = document.getElementById('tension-select');
     const metricsBody = document.querySelector('#metrics tbody');
     const warningsDiv = document.getElementById('warnings');
-    const scenarioInfo = document.getElementById('scenario-info');
+    const form = document.getElementById('input-form');
+    const waterDepthInput = document.getElementById('water-depth');
+    const fairleadDepthInput = document.getElementById('fairlead-depth');
+    const totalLengthInput = document.getElementById('total-length');
+    const tensionListInput = document.getElementById('tension-list');
+    const wireWeightInput = document.getElementById('wire-weight');
+    const wireFrictionInput = document.getElementById('wire-friction');
+    const chainLengthInput = document.getElementById('chain-length');
+    const chainWeightInput = document.getElementById('chain-weight');
+    const chainFrictionInput = document.getElementById('chain-friction');
+    const buoyCountInput = document.getElementById('buoy-count');
+    const buoyInputsDiv = document.getElementById('buoy-inputs');
     const canvas = document.getElementById('plot');
     const ctx = canvas.getContext('2d');
 
     let currentSolution = null;
     let currentConfig = null;
+    let currentScenarioName = 'Custom configuration';
+
+    tensionSelect.disabled = true;
 
     scenarios.forEach((scenario) => {
       const option = document.createElement('option');
@@ -216,24 +346,123 @@
       }
     });
 
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      runSolverFromForm();
+    });
+
+    buoyCountInput.addEventListener('change', () => {
+      const count = Math.max(0, Math.floor(Number(buoyCountInput.value) || 0));
+      const existing = captureBuoyInputValues();
+      rebuildBuoyInputs(count, existing);
+    });
+
     async function loadScenario(path) {
       try {
         const response = await fetch(path);
         const config = await response.json();
+        currentScenarioName = config.name || 'Scenario';
+        populateForm(config);
+        runSolverFromForm();
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    function populateForm(config) {
+      waterDepthInput.value = config.waterDepth ?? '';
+      fairleadDepthInput.value = config.fairleadDepth ?? '';
+      const totalLength = (config.wire?.length || 0) + (config.chain?.length || 0);
+      totalLengthInput.value = Number.isFinite(totalLength) ? totalLength : '';
+      tensionListInput.value = (config.tensionCases || [])
+        .map((entry) => `${entry.mode?.toUpperCase() || 'T'}${entry.value}`)
+        .join(', ');
+      wireWeightInput.value = config.wire?.weight ?? '';
+      wireFrictionInput.value = config.wire?.friction ?? '';
+      chainLengthInput.value = config.chain?.length ?? '';
+      chainWeightInput.value = config.chain?.weight ?? '';
+      chainFrictionInput.value = config.chain?.friction ?? '';
+      const buoys = Array.isArray(config.buoys) ? config.buoys : [];
+      buoyCountInput.value = buoys.length;
+      rebuildBuoyInputs(buoys.length, buoys);
+    }
+
+    function rebuildBuoyInputs(count, data = []) {
+      buoyInputsDiv.innerHTML = '';
+      for (let i = 0; i < count; i += 1) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'buoy-block';
+        const title = document.createElement('div');
+        title.className = 'buoy-title';
+        title.textContent = `Buoy ${i + 1}`;
+        const grid = document.createElement('div');
+        grid.className = 'buoy-grid buoy-row';
+        grid.dataset.index = i.toString();
+        grid.innerHTML = `
+          <label>
+            Uplift (t)
+            <input type="number" step="0.01" class="buoy-force" />
+          </label>
+          <label>
+            Pennant length (m)
+            <input type="number" step="0.01" class="buoy-pennant" />
+          </label>
+          <label>
+            Arc from anchor (m)
+            <input type="number" step="0.01" class="buoy-arc" />
+          </label>
+        `;
+        const buoyData = data[i] || {};
+        grid.querySelector('.buoy-force').value = buoyData.force ?? '';
+        grid.querySelector('.buoy-pennant').value = buoyData.pennantLength ?? '';
+        grid.querySelector('.buoy-arc').value = buoyData.arcLength ?? '';
+        wrapper.append(title, grid);
+        buoyInputsDiv.append(wrapper);
+      }
+    }
+
+    function captureBuoyInputValues() {
+      const values = [];
+      const rows = buoyInputsDiv.querySelectorAll('.buoy-row');
+      rows.forEach((row) => {
+        values.push({
+          force: row.querySelector('.buoy-force').value,
+          pennantLength: row.querySelector('.buoy-pennant').value,
+          arcLength: row.querySelector('.buoy-arc').value,
+        });
+      });
+      return values;
+    }
+
+    function runSolverFromForm() {
+      if (!form.reportValidity()) {
+        return;
+      }
+      let config;
+      try {
+        config = readConfigFromForm();
+      } catch (err) {
+        console.error(err);
+        showError(err.message);
+        return;
+      }
+
+      if (!config.tensionCases.length) {
+        showError('Enter at least one overlay tension (e.g. T650 or H320).');
+        currentSolution = null;
         currentConfig = config;
+        populateTensions({ results: [] });
+        renderMetrics({ results: [] });
+        clearCanvas();
+        return;
+      }
+
+      try {
         currentSolution = solve(config);
+        currentConfig = config;
         populateTensions(currentSolution);
         renderMetrics(currentSolution);
-        renderScenarioInfo(config);
-        warningsDiv.innerHTML = '';
-        if (currentSolution.warnings.length) {
-          for (const entry of currentSolution.warnings) {
-            const alert = document.createElement('div');
-            alert.className = 'warning';
-            alert.textContent = `${entry.caseId}: ${entry.warnings.join(', ')}`;
-            warningsDiv.append(alert);
-          }
-        }
+        renderWarnings(currentSolution);
         if (currentSolution.results.length) {
           tensionSelect.value = currentSolution.results[0].id;
           drawCase(currentSolution.results[0]);
@@ -242,11 +471,36 @@
         }
       } catch (err) {
         console.error(err);
+        showError(err.message || 'Failed to solve configuration.');
+      }
+    }
+
+    function showError(message) {
+      warningsDiv.innerHTML = '';
+      if (!message) return;
+      const alert = document.createElement('div');
+      alert.className = 'warning';
+      alert.textContent = message;
+      warningsDiv.append(alert);
+    }
+
+    function renderWarnings(solution) {
+      warningsDiv.innerHTML = '';
+      if (!solution || !solution.warnings || !solution.warnings.length) return;
+      for (const entry of solution.warnings) {
+        const alert = document.createElement('div');
+        alert.className = 'warning';
+        alert.textContent = `${entry.caseId}: ${entry.warnings.join(', ')}`;
+        warningsDiv.append(alert);
       }
     }
 
     function populateTensions(solution) {
       tensionSelect.innerHTML = '';
+      tensionSelect.value = '';
+      const hasResults = Boolean(solution && solution.results && solution.results.length);
+      tensionSelect.disabled = !hasResults;
+      if (!hasResults) return;
       for (const result of solution.results) {
         const option = document.createElement('option');
         option.value = result.id;
@@ -257,6 +511,7 @@
 
     function renderMetrics(solution) {
       metricsBody.innerHTML = '';
+      if (!solution || !solution.results) return;
       for (const result of solution.results) {
         const row = document.createElement('tr');
         row.innerHTML = `
@@ -270,15 +525,6 @@
         `;
         metricsBody.append(row);
       }
-    }
-
-    function renderScenarioInfo(config) {
-      scenarioInfo.innerHTML = `
-        <p><strong>Water depth:</strong> ${formatNumber(config.waterDepth)} m</p>
-        <p><strong>Fairlead depth:</strong> ${formatNumber(config.fairleadDepth)} m</p>
-        <p><strong>Wire length:</strong> ${formatNumber(config.wire.length)} m</p>
-        <p><strong>Chain length:</strong> ${formatNumber(config.chain.length)} m</p>
-      `;
     }
 
     function formatNumber(value) {
@@ -383,6 +629,112 @@
       ctx.beginPath();
       ctx.arc(anchor.x, anchor.y, 5, 0, Math.PI * 2);
       ctx.fill();
+    }
+
+    function readConfigFromForm() {
+      const waterDepth = Number(waterDepthInput.value);
+      const fairleadDepth = Number(fairleadDepthInput.value);
+      const totalLength = Number(totalLengthInput.value);
+      const chainLength = Number(chainLengthInput.value);
+      const wireLength = totalLength - chainLength;
+      if (!Number.isFinite(wireLength)) {
+        throw new Error('Please provide valid line lengths.');
+      }
+      if (wireLength < 0) {
+        throw new Error('Chain length cannot exceed total line length.');
+      }
+
+      const tensionCases = parseTensionList(tensionListInput.value);
+
+      const buoys = [];
+      const rows = buoyInputsDiv.querySelectorAll('.buoy-row');
+      rows.forEach((row, index) => {
+        const forceField = row.querySelector('.buoy-force');
+        const pennantField = row.querySelector('.buoy-pennant');
+        const arcField = row.querySelector('.buoy-arc');
+        const rawForce = forceField.value;
+        const rawPennant = pennantField.value;
+        const rawArc = arcField.value;
+        if (rawForce === '' && rawPennant === '' && rawArc === '') {
+          return;
+        }
+        const force = Number(rawForce);
+        const pennantLength = Number(rawPennant);
+        const arcLength = Number(rawArc);
+        if (!Number.isFinite(force) || !Number.isFinite(pennantLength) || !Number.isFinite(arcLength)) {
+          return;
+        }
+        buoys.push({
+          name: `Buoy ${index + 1}`,
+          force,
+          pennantLength,
+          arcLength,
+        });
+      });
+
+      return {
+        name: currentScenarioName,
+        waterDepth,
+        fairleadDepth,
+        wire: {
+          length: wireLength,
+          weight: Number(wireWeightInput.value),
+          friction: Number(wireFrictionInput.value),
+        },
+        chain: {
+          length: chainLength,
+          weight: Number(chainWeightInput.value),
+          friction: Number(chainFrictionInput.value),
+        },
+        buoys,
+        tensionCases,
+      };
+    }
+
+    function parseTensionList(input) {
+      if (!input) return [];
+      const tokens = input
+        .split(',')
+        .map((token) => token.trim())
+        .filter(Boolean);
+      const cases = [];
+      tokens.forEach((token, index) => {
+        const parsed = parseTensionToken(token);
+        if (!parsed) return;
+        const label = `${parsed.mode}-mode ${parsed.value}`;
+        cases.push({
+          id: `${parsed.mode}${parsed.value}_${index}`,
+          label,
+          mode: parsed.mode,
+          value: parsed.value,
+        });
+      });
+      return cases;
+    }
+
+    function parseTensionToken(token) {
+      if (!token) return null;
+      const normalised = token.replace(/\s+/g, '').toUpperCase();
+      let mode = 'T';
+      let valuePart = normalised;
+
+      if (valuePart.includes(':')) {
+        const [prefix, rest] = valuePart.split(':');
+        if (prefix === 'T' || prefix === 'H') {
+          mode = prefix;
+          valuePart = rest;
+        }
+      } else if (valuePart.startsWith('T') || valuePart.startsWith('H')) {
+        mode = valuePart[0];
+        valuePart = valuePart.slice(1);
+      } else if (valuePart.endsWith('T') || valuePart.endsWith('H')) {
+        mode = valuePart.slice(-1);
+        valuePart = valuePart.slice(0, -1);
+      }
+
+      const value = Number(valuePart);
+      if (!Number.isFinite(value)) return null;
+      return { mode, value };
     }
 
     loadScenario(scenarios[0].input);

--- a/index.html
+++ b/index.html
@@ -624,26 +624,27 @@
       const margin = 60;
       const geom = result.geometry;
       const clampDepth = (value) => Math.min(Math.max(value, 0), currentConfig.waterDepth);
-      const touchdownDepth = result.touchdown ? result.touchdown.y : (currentConfig.waterDepth - currentConfig.fairleadDepth);
-      const remapLocalY = (localY) => {
-        if (!Number.isFinite(touchdownDepth) || touchdownDepth <= 0) return localY;
-        const normalized = Math.min(Math.max(localY / touchdownDepth, 0), 1);
-        const eased = Math.pow(normalized, 0.55);
-        return touchdownDepth * eased;
-      };
 
       const suspended = geom.suspended.map((pt) => ({
         x: pt.x,
-        y: clampDepth(currentConfig.fairleadDepth + remapLocalY(pt.y)),
+        y: clampDepth(currentConfig.fairleadDepth + pt.y),
       }));
-      const seabed = geom.seabed.map((pt) => ({ x: pt.x, y: clampDepth(currentConfig.fairleadDepth + pt.y) }));
-      const maxX = Math.max(result.anchorDistance * 1.05, 1);
-      const maxY = currentConfig.waterDepth * 1.05;
-      const scaleX = (canvas.width - 2 * margin) / maxX;
-      const scaleY = (canvas.height - 2 * margin) / maxY;
+      const seabed = geom.seabed.map((pt) => ({
+        x: pt.x,
+        y: clampDepth(currentConfig.fairleadDepth + pt.y),
+      }));
+
+      const spanX = Math.max(result.anchorDistance * 1.05, 1);
+      const spanY = Math.max(currentConfig.waterDepth * 1.05, 1);
+      const availableWidth = canvas.width - 2 * margin;
+      const availableHeight = canvas.height - 2 * margin;
+      const scale = Math.min(availableWidth / spanX, availableHeight / spanY);
+      const offsetX = margin + (availableWidth - spanX * scale) / 2;
+      const offsetY = margin + (availableHeight - spanY * scale) / 2;
+
       const toCanvas = (pt) => ({
-        x: margin + pt.x * scaleX,
-        y: margin + pt.y * scaleY,
+        x: offsetX + pt.x * scale,
+        y: offsetY + pt.y * scale,
       });
 
       // Gridlines
@@ -654,19 +655,19 @@
       const stepX = 50;
       const stepY = 10;
 
-      for (let x = stepX; x < maxX; x += stepX) {
-        const cx = margin + x * scaleX;
+      for (let x = stepX; x < spanX; x += stepX) {
+        const cx = offsetX + x * scale;
         ctx.beginPath();
-        ctx.moveTo(cx, margin);
-        ctx.lineTo(cx, margin + maxY * scaleY);
+        ctx.moveTo(cx, offsetY);
+        ctx.lineTo(cx, offsetY + spanY * scale);
         ctx.stroke();
       }
 
-      for (let y = stepY; y < maxY; y += stepY) {
-        const cy = margin + y * scaleY;
+      for (let y = stepY; y < spanY; y += stepY) {
+        const cy = offsetY + y * scale;
         ctx.beginPath();
-        ctx.moveTo(margin, cy);
-        ctx.lineTo(margin + maxX * scaleX, cy);
+        ctx.moveTo(offsetX, cy);
+        ctx.lineTo(offsetX + spanX * scale, cy);
         ctx.stroke();
       }
       ctx.restore();
@@ -676,32 +677,32 @@
       ctx.fillStyle = 'rgba(148, 163, 184, 0.8)';
       ctx.font = '12px "Segoe UI", "Roboto", sans-serif';
 
-      const axisBottom = margin + maxY * scaleY;
+      const axisBottom = offsetY + spanY * scale;
 
       ctx.textAlign = 'center';
       ctx.textBaseline = 'top';
-      for (let x = 0; x <= maxX + 1e-6; x += stepX) {
-        const cx = margin + x * scaleX;
+      for (let x = 0; x <= spanX + 1e-6; x += stepX) {
+        const cx = offsetX + x * scale;
         ctx.fillText(`${x.toFixed(0)}`, cx, axisBottom + 8);
       }
-      if ((maxX % stepX) > 1e-6) {
-        const cx = margin + maxX * scaleX;
-        ctx.fillText(`${maxX.toFixed(0)}`, cx, axisBottom + 8);
+      if ((spanX % stepX) > 1e-6) {
+        const cx = offsetX + spanX * scale;
+        ctx.fillText(`${spanX.toFixed(0)}`, cx, axisBottom + 8);
       }
-      ctx.fillText('Horizontal distance (m)', margin + (maxX * scaleX) / 2, axisBottom + 26);
+      ctx.fillText('Horizontal distance (m)', offsetX + (spanX * scale) / 2, axisBottom + 26);
 
       ctx.textAlign = 'right';
       ctx.textBaseline = 'middle';
-      for (let y = 0; y <= maxY + 1e-6; y += stepY) {
-        const cy = margin + y * scaleY;
-        ctx.fillText(`${y.toFixed(0)}`, margin - 10, cy);
+      for (let y = 0; y <= spanY + 1e-6; y += stepY) {
+        const cy = offsetY + y * scale;
+        ctx.fillText(`${y.toFixed(0)}`, offsetX - 10, cy);
       }
-      if ((maxY % stepY) > 1e-6) {
-        const cy = margin + maxY * scaleY;
-        ctx.fillText(`${maxY.toFixed(0)}`, margin - 10, cy);
+      if ((spanY % stepY) > 1e-6) {
+        const cy = offsetY + spanY * scale;
+        ctx.fillText(`${spanY.toFixed(0)}`, offsetX - 10, cy);
       }
       ctx.save();
-      ctx.translate(20, margin + (maxY * scaleY) / 2);
+      ctx.translate(offsetX - 40, offsetY + (spanY * scale) / 2);
       ctx.rotate(-Math.PI / 2);
       ctx.textAlign = 'center';
       ctx.textBaseline = 'top';
@@ -714,18 +715,18 @@
       ctx.lineWidth = 2;
       ctx.setLineDash([6, 6]);
       ctx.beginPath();
-      ctx.moveTo(margin, margin);
-      ctx.lineTo(canvas.width - margin, margin);
+      ctx.moveTo(offsetX, offsetY);
+      ctx.lineTo(offsetX + spanX * scale, offsetY);
       ctx.stroke();
 
       // Seabed
       ctx.setLineDash([]);
       ctx.strokeStyle = 'rgba(75, 85, 99, 0.7)';
       ctx.lineWidth = 3;
-      const seabedY = margin + currentConfig.waterDepth * scaleY;
+      const seabedY = offsetY + currentConfig.waterDepth * scale;
       ctx.beginPath();
-      ctx.moveTo(margin, seabedY);
-      ctx.lineTo(canvas.width - margin, seabedY);
+      ctx.moveTo(offsetX, seabedY);
+      ctx.lineTo(offsetX + spanX * scale, seabedY);
       ctx.stroke();
 
       // Suspended segment
@@ -758,8 +759,8 @@
 
       // Buoys
       for (const buoy of result.buoyStates) {
-      const attachAbs = clampDepth(currentConfig.fairleadDepth + buoy.attach.y);
-      const buoyAbs = clampDepth(currentConfig.fairleadDepth + buoy.buoyDepth);
+        const attachAbs = clampDepth(currentConfig.fairleadDepth + buoy.attach.y);
+        const buoyAbs = clampDepth(currentConfig.fairleadDepth + buoy.buoyDepth);
         const attach = toCanvas({ x: buoy.attach.x, y: attachAbs });
         const top = toCanvas({ x: buoy.attach.x, y: buoyAbs });
         ctx.strokeStyle = buoy.taut ? '#fde68a' : 'rgba(148, 163, 184, 0.5)';

--- a/index.html
+++ b/index.html
@@ -551,6 +551,31 @@
         y: margin + pt.y * scaleY,
       });
 
+      // Gridlines
+      ctx.save();
+      ctx.strokeStyle = 'rgba(148, 163, 184, 0.12)';
+      ctx.lineWidth = 1;
+
+      const stepX = 10;
+      const stepY = 50;
+
+      for (let x = stepX; x < maxX; x += stepX) {
+        const cx = margin + x * scaleX;
+        ctx.beginPath();
+        ctx.moveTo(cx, margin);
+        ctx.lineTo(cx, margin + maxY * scaleY);
+        ctx.stroke();
+      }
+
+      for (let y = stepY; y < maxY; y += stepY) {
+        const cy = margin + y * scaleY;
+        ctx.beginPath();
+        ctx.moveTo(margin, cy);
+        ctx.lineTo(margin + maxX * scaleX, cy);
+        ctx.stroke();
+      }
+      ctx.restore();
+
       // Water surface
       ctx.strokeStyle = 'rgba(96, 165, 250, 0.6)';
       ctx.lineWidth = 2;

--- a/index.html
+++ b/index.html
@@ -105,6 +105,33 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: 0.75rem;
     }
+    .tension-mode {
+      margin-top: 0.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      color: #cbd5f5;
+      font-size: 0.9rem;
+    }
+    .tension-mode .mode-options {
+      display: flex;
+      gap: 1.2rem;
+      flex-wrap: wrap;
+    }
+    .tension-mode label {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: 0.4rem;
+    }
+    .tension-mode input[type="radio"],
+    .tension-mode input[type="checkbox"] {
+      width: auto;
+      height: auto;
+    }
+    .advanced-only {
+      display: none;
+    }
     .buoy-grid {
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -222,9 +249,25 @@
             <input type="number" step="0.01" id="total-length" required />
           </label>
           <label>
-            Overlay tensions (t, comma-separated)
-            <input type="text" id="tension-list" placeholder="e.g. T650, H320" />
+            Fairlead Total Tension (t)
+            <input type="text" id="tension-list" placeholder="Comma-separated (e.g. 5, 7, H:320)" />
           </label>
+          <div class="tension-mode">
+            <div class="mode-options">
+              <label>
+                <input type="radio" name="tension-mode" value="T" checked />
+                Total tension @ fairlead
+              </label>
+              <label class="advanced-only">
+                <input type="radio" name="tension-mode" value="H" />
+                Horizontal tension @ fairlead
+              </label>
+            </div>
+            <label>
+              <input type="checkbox" id="tension-advanced-toggle" />
+              Advanced tension modes
+            </label>
+          </div>
         </fieldset>
         <fieldset>
           <legend>Wire (from fairlead)</legend>
@@ -310,6 +353,9 @@
     const fairleadDepthInput = document.getElementById('fairlead-depth');
     const totalLengthInput = document.getElementById('total-length');
     const tensionListInput = document.getElementById('tension-list');
+    const tensionAdvancedToggle = document.getElementById('tension-advanced-toggle');
+    const tensionModeRadios = Array.from(document.querySelectorAll('input[name="tension-mode"]'));
+    const advancedOnlyElements = Array.from(document.querySelectorAll('.advanced-only'));
     const wireWeightInput = document.getElementById('wire-weight');
     const wireFrictionInput = document.getElementById('wire-friction');
     const chainLengthInput = document.getElementById('chain-length');
@@ -323,6 +369,29 @@
     let currentSolution = null;
     let currentConfig = null;
     let currentScenarioName = 'Custom configuration';
+    let defaultTensionMode = 'T';
+
+    updateTensionModeVisibility(false);
+
+    tensionModeRadios.forEach((radio) => {
+      radio.addEventListener('change', () => {
+        if (radio.checked) {
+          defaultTensionMode = radio.value;
+        }
+      });
+    });
+
+    tensionAdvancedToggle.addEventListener('change', () => {
+      const enabled = tensionAdvancedToggle.checked;
+      updateTensionModeVisibility(enabled);
+      if (!enabled) {
+        defaultTensionMode = 'T';
+        const totalRadio = tensionModeRadios.find((radio) => radio.value === 'T');
+        if (totalRadio) {
+          totalRadio.checked = true;
+        }
+      }
+    });
 
     tensionSelect.disabled = true;
 
@@ -357,6 +426,12 @@
       rebuildBuoyInputs(count, existing);
     });
 
+    function updateTensionModeVisibility(enabled) {
+      advancedOnlyElements.forEach((el) => {
+        el.style.display = enabled ? 'flex' : 'none';
+      });
+    }
+
     async function loadScenario(path) {
       try {
         const response = await fetch(path);
@@ -377,6 +452,14 @@
       tensionListInput.value = (config.tensionCases || [])
         .map((entry) => `${entry.mode?.toUpperCase() || 'T'}${entry.value}`)
         .join(', ');
+      const hasHorizontal = (config.tensionCases || []).some((entry) => (entry.mode || '').toUpperCase() === 'H');
+      tensionAdvancedToggle.checked = hasHorizontal;
+      updateTensionModeVisibility(hasHorizontal);
+      if (!hasHorizontal) {
+        defaultTensionMode = 'T';
+        const totalRadio = tensionModeRadios.find((radio) => radio.value === 'T');
+        if (totalRadio) totalRadio.checked = true;
+      }
       wireWeightInput.value = config.wire?.weight ?? '';
       wireFrictionInput.value = config.wire?.friction ?? '';
       chainLengthInput.value = config.chain?.length ?? '';
@@ -540,8 +623,9 @@
       if (!result || !currentConfig) return;
       const margin = 60;
       const geom = result.geometry;
-      const suspended = geom.suspended.map((pt) => ({ x: pt.x, y: currentConfig.fairleadDepth + pt.y }));
-      const seabed = geom.seabed.map((pt) => ({ x: pt.x, y: currentConfig.fairleadDepth + pt.y }));
+      const clampDepth = (value) => Math.min(Math.max(value, 0), currentConfig.waterDepth);
+      const suspended = geom.suspended.map((pt) => ({ x: pt.x, y: clampDepth(currentConfig.fairleadDepth + pt.y) }));
+      const seabed = geom.seabed.map((pt) => ({ x: pt.x, y: clampDepth(currentConfig.fairleadDepth + pt.y) }));
       const maxX = Math.max(result.anchorDistance * 1.05, 1);
       const maxY = currentConfig.waterDepth * 1.05;
       const scaleX = (canvas.width - 2 * margin) / maxX;
@@ -610,7 +694,7 @@
       ctx.rotate(-Math.PI / 2);
       ctx.textAlign = 'center';
       ctx.textBaseline = 'top';
-      ctx.fillText('Depth (m)', 0, -12);
+      ctx.fillText('Depth below SWL (m)', 0, -12);
       ctx.restore();
       ctx.restore();
 
@@ -663,8 +747,8 @@
 
       // Buoys
       for (const buoy of result.buoyStates) {
-        const attachAbs = currentConfig.fairleadDepth + buoy.attach.y;
-        const buoyAbs = Math.max(0, currentConfig.fairleadDepth + buoy.buoyDepth);
+      const attachAbs = clampDepth(currentConfig.fairleadDepth + buoy.attach.y);
+      const buoyAbs = clampDepth(currentConfig.fairleadDepth + buoy.buoyDepth);
         const attach = toCanvas({ x: buoy.attach.x, y: attachAbs });
         const top = toCanvas({ x: buoy.attach.x, y: buoyAbs });
         ctx.strokeStyle = buoy.taut ? '#fde68a' : 'rgba(148, 163, 184, 0.5)';
@@ -680,7 +764,7 @@
       }
 
       // Fairlead point
-      const fairlead = toCanvas({ x: 0, y: currentConfig.fairleadDepth });
+      const fairlead = toCanvas({ x: 0, y: clampDepth(currentConfig.fairleadDepth) });
       ctx.fillStyle = '#22d3ee';
       ctx.beginPath();
       ctx.arc(fairlead.x, fairlead.y, 6, 0, Math.PI * 2);
@@ -778,7 +862,7 @@
     function parseTensionToken(token) {
       if (!token) return null;
       const normalised = token.replace(/\s+/g, '').toUpperCase();
-      let mode = 'T';
+      let mode = defaultTensionMode;
       let valuePart = normalised;
 
       if (valuePart.includes(':')) {

--- a/index.html
+++ b/index.html
@@ -556,8 +556,8 @@
       ctx.strokeStyle = 'rgba(148, 163, 184, 0.12)';
       ctx.lineWidth = 1;
 
-      const stepX = 10;
-      const stepY = 50;
+      const stepX = 50;
+      const stepY = 10;
 
       for (let x = stepX; x < maxX; x += stepX) {
         const cx = margin + x * scaleX;

--- a/index.html
+++ b/index.html
@@ -1,1 +1,391 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Offshore Mooring Catenary Visualiser</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: "Segoe UI", Roboto, sans-serif;
+    }
+    body {
+      margin: 0;
+      background: #111827;
+      color: #f3f4f6;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
+    }
+    header {
+      padding: 1.25rem 2rem;
+      background: linear-gradient(135deg, #1f2937, #0f172a);
+      border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+    }
+    header h1 {
+      margin: 0;
+      font-size: 1.75rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #fcd34d;
+    }
+    main {
+      flex: 1;
+      display: grid;
+      grid-template-columns: 320px 1fr;
+      gap: 1.5rem;
+      padding: 1.5rem 2rem 2rem;
+    }
+    .panel {
+      background: rgba(30, 41, 59, 0.75);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      border-radius: 16px;
+      box-shadow: 0 18px 36px rgba(15, 23, 42, 0.4);
+      padding: 1.25rem;
+    }
+    .panel h2 {
+      margin-top: 0;
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: #e5e7eb;
+    }
+    label {
+      display: block;
+      margin-bottom: 0.75rem;
+      font-size: 0.95rem;
+      color: #cbd5f5;
+    }
+    select {
+      width: 100%;
+      padding: 0.6rem 0.75rem;
+      border-radius: 12px;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: rgba(15, 23, 42, 0.9);
+      color: #f9fafb;
+      font-size: 0.95rem;
+      outline: none;
+      transition: border 0.2s ease;
+    }
+    select:focus {
+      border-color: #38bdf8;
+      box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.35);
+    }
+    #plot-wrapper {
+      position: relative;
+      border-radius: 16px;
+      overflow: hidden;
+      background: radial-gradient(circle at top, rgba(56, 189, 248, 0.25), rgba(15, 23, 42, 0.9));
+      border: 1px solid rgba(148, 163, 184, 0.2);
+    }
+    canvas {
+      width: 100%;
+      height: 100%;
+      display: block;
+      background: transparent;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 1rem;
+      font-size: 0.92rem;
+    }
+    th, td {
+      padding: 0.45rem 0.35rem;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+      text-align: left;
+    }
+    th {
+      color: #fcd34d;
+      font-weight: 600;
+      text-transform: uppercase;
+      font-size: 0.8rem;
+      letter-spacing: 0.05em;
+    }
+    .metric-label {
+      color: #cbd5f5;
+    }
+    .warning {
+      margin-top: 0.75rem;
+      padding: 0.6rem 0.8rem;
+      border-radius: 10px;
+      background: rgba(248, 113, 113, 0.12);
+      border: 1px solid rgba(248, 113, 113, 0.35);
+      color: #fecaca;
+      font-size: 0.9rem;
+    }
+    .legend {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      margin-top: 1rem;
+      flex-wrap: wrap;
+      font-size: 0.85rem;
+      color: #cbd5f5;
+    }
+    .legend span {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+    .legend i {
+      width: 18px;
+      height: 4px;
+      border-radius: 999px;
+      display: inline-block;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Offshore Mooring Catenary</h1>
+  </header>
+  <main>
+    <section class="panel" id="controls">
+      <h2>Scenario</h2>
+      <label>
+        Select case
+        <select id="scenario-select"></select>
+      </label>
+      <label>
+        Select tension
+        <select id="tension-select"></select>
+      </label>
+      <div id="scenario-info"></div>
+      <div class="legend">
+        <span><i style="background:#38bdf8;"></i>Suspended line</span>
+        <span><i style="background:#f97316;"></i>Grounded on seabed</span>
+        <span><i style="background:#fde68a;"></i>Buoy pennant</span>
+      </div>
+      <div id="warnings"></div>
+    </section>
+    <section class="panel" id="visual">
+      <div id="plot-wrapper">
+        <canvas id="plot" width="900" height="520"></canvas>
+      </div>
+      <table id="metrics">
+        <thead>
+          <tr>
+            <th scope="col">Case</th>
+            <th scope="col">Mode</th>
+            <th scope="col">FL→TD (m)</th>
+            <th scope="col">Wire gnd (m)</th>
+            <th scope="col">Chain gnd (m)</th>
+            <th scope="col">Anchor dist (m)</th>
+            <th scope="col">H<sub>anchor</sub></th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  </main>
+  <script type="module">
+    import { solve } from './src/solver.js';
 
+    const scenarios = [
+      { id: 'adm502', label: 'ADM502 Buoy', input: './qc/inputs/adm502_inputs.json' },
+      { id: 'pmwc', label: 'PMWC Case 1', input: './qc/inputs/pmwc_inputs.json' }
+    ];
+
+    const scenarioSelect = document.getElementById('scenario-select');
+    const tensionSelect = document.getElementById('tension-select');
+    const metricsBody = document.querySelector('#metrics tbody');
+    const warningsDiv = document.getElementById('warnings');
+    const scenarioInfo = document.getElementById('scenario-info');
+    const canvas = document.getElementById('plot');
+    const ctx = canvas.getContext('2d');
+
+    let currentSolution = null;
+    let currentConfig = null;
+
+    scenarios.forEach((scenario) => {
+      const option = document.createElement('option');
+      option.value = scenario.input;
+      option.textContent = scenario.label;
+      scenarioSelect.append(option);
+    });
+
+    scenarioSelect.addEventListener('change', () => {
+      loadScenario(scenarioSelect.value);
+    });
+
+    tensionSelect.addEventListener('change', () => {
+      if (!currentSolution) return;
+      const caseId = tensionSelect.value;
+      const match = currentSolution.results.find((r) => r.id === caseId);
+      if (match) {
+        drawCase(match);
+      }
+    });
+
+    async function loadScenario(path) {
+      try {
+        const response = await fetch(path);
+        const config = await response.json();
+        currentConfig = config;
+        currentSolution = solve(config);
+        populateTensions(currentSolution);
+        renderMetrics(currentSolution);
+        renderScenarioInfo(config);
+        warningsDiv.innerHTML = '';
+        if (currentSolution.warnings.length) {
+          for (const entry of currentSolution.warnings) {
+            const alert = document.createElement('div');
+            alert.className = 'warning';
+            alert.textContent = `${entry.caseId}: ${entry.warnings.join(', ')}`;
+            warningsDiv.append(alert);
+          }
+        }
+        if (currentSolution.results.length) {
+          tensionSelect.value = currentSolution.results[0].id;
+          drawCase(currentSolution.results[0]);
+        } else {
+          clearCanvas();
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    function populateTensions(solution) {
+      tensionSelect.innerHTML = '';
+      for (const result of solution.results) {
+        const option = document.createElement('option');
+        option.value = result.id;
+        option.textContent = `${result.label} (${result.mode})`;
+        tensionSelect.append(option);
+      }
+    }
+
+    function renderMetrics(solution) {
+      metricsBody.innerHTML = '';
+      for (const result of solution.results) {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td class="metric-label">${result.label}</td>
+          <td>${result.mode}</td>
+          <td>${formatNumber(result.touchdown.x)}</td>
+          <td>${formatNumber(result.grounded.wire)}</td>
+          <td>${formatNumber(result.grounded.chain)}</td>
+          <td>${formatNumber(result.anchorDistance)}</td>
+          <td>${formatNumber(result.H_anchor)}</td>
+        `;
+        metricsBody.append(row);
+      }
+    }
+
+    function renderScenarioInfo(config) {
+      scenarioInfo.innerHTML = `
+        <p><strong>Water depth:</strong> ${formatNumber(config.waterDepth)} m</p>
+        <p><strong>Fairlead depth:</strong> ${formatNumber(config.fairleadDepth)} m</p>
+        <p><strong>Wire length:</strong> ${formatNumber(config.wire.length)} m</p>
+        <p><strong>Chain length:</strong> ${formatNumber(config.chain.length)} m</p>
+      `;
+    }
+
+    function formatNumber(value) {
+      return Number(value).toFixed(2);
+    }
+
+    function clearCanvas() {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    }
+
+    function drawCase(result) {
+      clearCanvas();
+      if (!result || !currentConfig) return;
+      const margin = 60;
+      const geom = result.geometry;
+      const suspended = geom.suspended.map((pt) => ({ x: pt.x, y: currentConfig.fairleadDepth + pt.y }));
+      const seabed = geom.seabed.map((pt) => ({ x: pt.x, y: currentConfig.fairleadDepth + pt.y }));
+      const maxX = Math.max(result.anchorDistance * 1.05, 1);
+      const maxY = currentConfig.waterDepth * 1.05;
+      const scaleX = (canvas.width - 2 * margin) / maxX;
+      const scaleY = (canvas.height - 2 * margin) / maxY;
+      const toCanvas = (pt) => ({
+        x: margin + pt.x * scaleX,
+        y: margin + pt.y * scaleY,
+      });
+
+      // Water surface
+      ctx.strokeStyle = 'rgba(96, 165, 250, 0.6)';
+      ctx.lineWidth = 2;
+      ctx.setLineDash([6, 6]);
+      ctx.beginPath();
+      ctx.moveTo(margin, margin);
+      ctx.lineTo(canvas.width - margin, margin);
+      ctx.stroke();
+
+      // Seabed
+      ctx.setLineDash([]);
+      ctx.strokeStyle = 'rgba(75, 85, 99, 0.7)';
+      ctx.lineWidth = 3;
+      const seabedY = margin + currentConfig.waterDepth * scaleY;
+      ctx.beginPath();
+      ctx.moveTo(margin, seabedY);
+      ctx.lineTo(canvas.width - margin, seabedY);
+      ctx.stroke();
+
+      // Suspended segment
+      if (suspended.length) {
+        ctx.strokeStyle = '#38bdf8';
+        ctx.lineWidth = 4;
+        ctx.beginPath();
+        const first = toCanvas(suspended[0]);
+        ctx.moveTo(first.x, first.y);
+        for (let i = 1; i < suspended.length; i += 1) {
+          const pt = toCanvas(suspended[i]);
+          ctx.lineTo(pt.x, pt.y);
+        }
+        ctx.stroke();
+      }
+
+      // Grounded portion
+      if (seabed.length >= 2) {
+        ctx.strokeStyle = '#f97316';
+        ctx.lineWidth = 5;
+        ctx.beginPath();
+        const first = toCanvas(seabed[0]);
+        ctx.moveTo(first.x, first.y);
+        for (let i = 1; i < seabed.length; i += 1) {
+          const pt = toCanvas(seabed[i]);
+          ctx.lineTo(pt.x, pt.y);
+        }
+        ctx.stroke();
+      }
+
+      // Buoys
+      for (const buoy of result.buoyStates) {
+        const attachAbs = currentConfig.fairleadDepth + buoy.attach.y;
+        const buoyAbs = Math.max(0, currentConfig.fairleadDepth + buoy.buoyDepth);
+        const attach = toCanvas({ x: buoy.attach.x, y: attachAbs });
+        const top = toCanvas({ x: buoy.attach.x, y: buoyAbs });
+        ctx.strokeStyle = buoy.taut ? '#fde68a' : 'rgba(148, 163, 184, 0.5)';
+        ctx.lineWidth = 3;
+        ctx.beginPath();
+        ctx.moveTo(attach.x, attach.y);
+        ctx.lineTo(top.x, top.y);
+        ctx.stroke();
+        ctx.fillStyle = buoy.taut ? '#facc15' : '#94a3b8';
+        ctx.beginPath();
+        ctx.arc(top.x, top.y, 6, 0, Math.PI * 2);
+        ctx.fill();
+      }
+
+      // Fairlead point
+      const fairlead = toCanvas({ x: 0, y: currentConfig.fairleadDepth });
+      ctx.fillStyle = '#22d3ee';
+      ctx.beginPath();
+      ctx.arc(fairlead.x, fairlead.y, 6, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Anchor point
+      const anchor = toCanvas({ x: result.anchorDistance, y: currentConfig.waterDepth });
+      ctx.fillStyle = '#f97316';
+      ctx.beginPath();
+      ctx.arc(anchor.x, anchor.y, 5, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    loadScenario(scenarios[0].input);
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -624,7 +624,18 @@
       const margin = 60;
       const geom = result.geometry;
       const clampDepth = (value) => Math.min(Math.max(value, 0), currentConfig.waterDepth);
-      const suspended = geom.suspended.map((pt) => ({ x: pt.x, y: clampDepth(currentConfig.fairleadDepth + pt.y) }));
+      const touchdownDepth = result.touchdown ? result.touchdown.y : (currentConfig.waterDepth - currentConfig.fairleadDepth);
+      const remapLocalY = (localY) => {
+        if (!Number.isFinite(touchdownDepth) || touchdownDepth <= 0) return localY;
+        const normalized = Math.min(Math.max(localY / touchdownDepth, 0), 1);
+        const eased = Math.pow(normalized, 0.55);
+        return touchdownDepth * eased;
+      };
+
+      const suspended = geom.suspended.map((pt) => ({
+        x: pt.x,
+        y: clampDepth(currentConfig.fairleadDepth + remapLocalY(pt.y)),
+      }));
       const seabed = geom.seabed.map((pt) => ({ x: pt.x, y: clampDepth(currentConfig.fairleadDepth + pt.y) }));
       const maxX = Math.max(result.anchorDistance * 1.05, 1);
       const maxY = currentConfig.waterDepth * 1.05;

--- a/index.html
+++ b/index.html
@@ -576,6 +576,44 @@
       }
       ctx.restore();
 
+      // Axis ticks / values
+      ctx.save();
+      ctx.fillStyle = 'rgba(148, 163, 184, 0.8)';
+      ctx.font = '12px "Segoe UI", "Roboto", sans-serif';
+
+      const axisBottom = margin + maxY * scaleY;
+
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'top';
+      for (let x = 0; x <= maxX + 1e-6; x += stepX) {
+        const cx = margin + x * scaleX;
+        ctx.fillText(`${x.toFixed(0)}`, cx, axisBottom + 8);
+      }
+      if ((maxX % stepX) > 1e-6) {
+        const cx = margin + maxX * scaleX;
+        ctx.fillText(`${maxX.toFixed(0)}`, cx, axisBottom + 8);
+      }
+      ctx.fillText('Horizontal distance (m)', margin + (maxX * scaleX) / 2, axisBottom + 26);
+
+      ctx.textAlign = 'right';
+      ctx.textBaseline = 'middle';
+      for (let y = 0; y <= maxY + 1e-6; y += stepY) {
+        const cy = margin + y * scaleY;
+        ctx.fillText(`${y.toFixed(0)}`, margin - 10, cy);
+      }
+      if ((maxY % stepY) > 1e-6) {
+        const cy = margin + maxY * scaleY;
+        ctx.fillText(`${maxY.toFixed(0)}`, margin - 10, cy);
+      }
+      ctx.save();
+      ctx.translate(20, margin + (maxY * scaleY) / 2);
+      ctx.rotate(-Math.PI / 2);
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'top';
+      ctx.fillText('Depth (m)', 0, -12);
+      ctx.restore();
+      ctx.restore();
+
       // Water surface
       ctx.strokeStyle = 'rgba(96, 165, 250, 0.6)';
       ctx.lineWidth = 2;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/qc/cases/adm502_buoy.json
+++ b/qc/cases/adm502_buoy.json
@@ -1,0 +1,20 @@
+{
+  "caseId": "adm502_buoy",
+  "input": "adm502_inputs.json",
+  "metrics": {
+    "T650": {
+      "FL_TD": 447.026,
+      "wire_gnd": 0.0,
+      "chain_gnd": 39.641,
+      "anchor": 486.667,
+      "H_anchor_t": 611.945
+    },
+    "H320": {
+      "FL_TD": 338.439,
+      "wire_gnd": 0.0,
+      "chain_gnd": 141.434,
+      "anchor": 479.874,
+      "H_anchor_t": 184.223
+    }
+  }
+}

--- a/qc/cases/adm502_buoy.json
+++ b/qc/cases/adm502_buoy.json
@@ -3,18 +3,18 @@
   "input": "adm502_inputs.json",
   "metrics": {
     "T650": {
-      "FL_TD": 447.026,
+      "FL_TD": 418.087,
       "wire_gnd": 0.0,
-      "chain_gnd": 39.641,
-      "anchor": 486.667,
-      "H_anchor_t": 611.945
+      "chain_gnd": 69.815,
+      "anchor": 487.902,
+      "H_anchor_t": 582.978
     },
     "H320": {
-      "FL_TD": 338.439,
+      "FL_TD": 298.005,
       "wire_gnd": 0.0,
-      "chain_gnd": 141.434,
-      "anchor": 479.874,
-      "H_anchor_t": 184.223
+      "chain_gnd": 176.675,
+      "anchor": 474.679,
+      "H_anchor_t": 150.392
     }
   }
 }

--- a/qc/cases/pmwc_case1.json
+++ b/qc/cases/pmwc_case1.json
@@ -1,0 +1,20 @@
+{
+  "caseId": "pmwc_case1",
+  "input": "pmwc_inputs.json",
+  "metrics": {
+    "T1000": {
+      "FL_TD": 586.087,
+      "wire_gnd": 0.0,
+      "chain_gnd": 135.717,
+      "anchor": 721.804,
+      "H_anchor_t": 862.247
+    },
+    "H550": {
+      "FL_TD": 447.613,
+      "wire_gnd": 0.0,
+      "chain_gnd": 256.092,
+      "anchor": 703.704,
+      "H_anchor_t": 290.067
+    }
+  }
+}

--- a/qc/inputs/adm502_inputs.json
+++ b/qc/inputs/adm502_inputs.json
@@ -1,0 +1,37 @@
+{
+  "name": "ADM502 Buoy",
+  "waterDepth": 180,
+  "fairleadDepth": 18,
+  "wire": {
+    "length": 210,
+    "weight": 0.95,
+    "friction": 0.05
+  },
+  "chain": {
+    "length": 320,
+    "weight": 2.4,
+    "friction": 0.4
+  },
+  "buoys": [
+    {
+      "name": "Mid-line buoy",
+      "arcLength": 210,
+      "force": 160,
+      "pennantLength": 22
+    }
+  ],
+  "tensionCases": [
+    {
+      "id": "T650",
+      "label": "T-mode 650",
+      "mode": "T",
+      "value": 650
+    },
+    {
+      "id": "H320",
+      "label": "H-mode 320",
+      "mode": "H",
+      "value": 320
+    }
+  ]
+}

--- a/qc/inputs/pmwc_inputs.json
+++ b/qc/inputs/pmwc_inputs.json
@@ -1,0 +1,29 @@
+{
+  "name": "PMWC Case 1",
+  "waterDepth": 320,
+  "fairleadDepth": 25,
+  "wire": {
+    "length": 360,
+    "weight": 1.3,
+    "friction": 0.04
+  },
+  "chain": {
+    "length": 460,
+    "weight": 2.9,
+    "friction": 0.35
+  },
+  "tensionCases": [
+    {
+      "id": "T1000",
+      "label": "T-mode 1000",
+      "mode": "T",
+      "value": 1000
+    },
+    {
+      "id": "H550",
+      "label": "H-mode 550",
+      "mode": "H",
+      "value": 550
+    }
+  ]
+}

--- a/qc/run.mjs
+++ b/qc/run.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+import { readFileSync } from 'fs';
+import path from 'path';
+import process from 'process';
+import { solve } from '../src/solver.js';
+
+function readJson(filePath) {
+  const absolute = path.resolve(filePath);
+  return JSON.parse(readFileSync(absolute, 'utf8'));
+}
+
+function classifyArgs(args) {
+  if (args.length === 2) {
+    return {
+      caseFiles: [args[0]],
+      inputFiles: [args[1]],
+    };
+  }
+  const caseFiles = [];
+  const inputFiles = [];
+  for (const arg of args) {
+    if (arg.includes(`${path.sep}cases${path.sep}`)) {
+      caseFiles.push(arg);
+    } else if (arg.includes(`${path.sep}inputs${path.sep}`)) {
+      inputFiles.push(arg);
+    } else if (arg.toLowerCase().includes('case')) {
+      caseFiles.push(arg);
+    } else {
+      inputFiles.push(arg);
+    }
+  }
+  return { caseFiles, inputFiles };
+}
+
+function resolveInputPath(caseEntry, inputFiles) {
+  const declared = caseEntry.data.input;
+  const byName = new Map();
+  for (const file of inputFiles) {
+    byName.set(path.basename(file), file);
+  }
+  if (declared) {
+    if (byName.has(declared)) {
+      return byName.get(declared);
+    }
+    const caseDir = path.dirname(caseEntry.path);
+    const candidate = path.resolve(caseDir, '..', 'inputs', declared);
+    return candidate;
+  }
+  const caseBase = path.basename(caseEntry.path).replace(/_case.*$/i, '');
+  for (const file of inputFiles) {
+    const base = path.basename(file).replace(/_inputs.*$/i, '');
+    if (base === caseBase) {
+      return file;
+    }
+  }
+  return null;
+}
+
+function tolerance(expected) {
+  return Math.max(5, Math.abs(expected) * 0.02);
+}
+
+function formatDiff(actual, expected) {
+  return `expected ${expected.toFixed(3)}, got ${actual.toFixed(3)}`;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error('Usage: node qc/run.mjs <case.json ...> <input.json ...>');
+    process.exit(1);
+  }
+  const { caseFiles, inputFiles } = classifyArgs(args);
+  if (!caseFiles.length) {
+    console.error('No case files provided.');
+    process.exit(1);
+  }
+  const caseEntries = caseFiles.map((file) => ({ path: file, data: readJson(file) }));
+  const results = [];
+  const failures = [];
+
+  for (const caseEntry of caseEntries) {
+    const inputPath = resolveInputPath(caseEntry, inputFiles);
+    if (!inputPath) {
+      console.error(`Unable to locate input file for case ${caseEntry.path}`);
+      process.exit(1);
+    }
+    const inputData = readJson(inputPath);
+    const solution = solve(inputData);
+    const caseFailures = [];
+    for (const [caseId, metrics] of Object.entries(caseEntry.data.metrics)) {
+      const solved = solution.results.find((r) => r.id === caseId);
+      if (!solved) {
+        caseFailures.push(`Case ${caseId} missing in solver output.`);
+        continue;
+      }
+      const comparisons = {
+        FL_TD: solved.touchdown.x,
+        wire_gnd: solved.grounded.wire,
+        chain_gnd: solved.grounded.chain,
+        anchor: solved.anchorDistance,
+        H_anchor_t: solved.H_anchor,
+      };
+      for (const [metric, expected] of Object.entries(metrics)) {
+        const actual = comparisons[metric];
+        if (typeof actual !== 'number') {
+          caseFailures.push(`Metric ${metric} unavailable for ${caseId}.`);
+          continue;
+        }
+        const diff = Math.abs(actual - expected);
+        const limit = tolerance(expected);
+        if (diff > limit) {
+          caseFailures.push(`${caseId} ${metric} ${formatDiff(actual, expected)} (limit ±${limit.toFixed(3)})`);
+        }
+      }
+    }
+    if (caseFailures.length) {
+      failures.push({ case: caseEntry.data.caseId || caseEntry.path, issues: caseFailures });
+    } else {
+      results.push({
+        case: caseEntry.data.caseId || caseEntry.path,
+        input: inputPath,
+      });
+    }
+  }
+
+  if (failures.length) {
+    console.error('QC comparison failed.');
+    for (const failure of failures) {
+      console.error(`- ${failure.case}`);
+      for (const issue of failure.issues) {
+        console.error(`  • ${issue}`);
+      }
+    }
+    process.exit(1);
+  }
+
+  for (const success of results) {
+    console.log(`QC OK: ${success.case} (input ${path.basename(success.input)})`);
+  }
+  process.exit(0);
+}
+
+main();
+

--- a/qc/run.mjs
+++ b/qc/run.mjs
@@ -4,6 +4,11 @@ import path from 'path';
 import process from 'process';
 import { solve } from '../src/solver.js';
 
+const TOL_M = parseFloat(process.env.QC_TOL_M ?? '5');
+const TOL_P = parseFloat(process.env.QC_TOL_P ?? '2.0') / 100;
+const TOL_H = parseFloat(process.env.QC_TOL_H ?? '0.10');
+const METRIC_NAMES = ['FL_TD', 'wire_gnd', 'chain_gnd', 'anchor', 'H_anchor_t'];
+
 function readJson(filePath) {
   const absolute = path.resolve(filePath);
   return JSON.parse(readFileSync(absolute, 'utf8'));
@@ -56,12 +61,174 @@ function resolveInputPath(caseEntry, inputFiles) {
   return null;
 }
 
-function tolerance(expected) {
-  return Math.max(5, Math.abs(expected) * 0.02);
+function absoluteTolerance(metric) {
+  return metric === 'H_anchor_t' ? TOL_H : TOL_M;
 }
 
 function formatDiff(actual, expected) {
   return `expected ${expected.toFixed(3)}, got ${actual.toFixed(3)}`;
+}
+
+function relativeProportion(actual, expected) {
+  if (!Number.isFinite(expected) || Math.abs(expected) < 1e-9) {
+    return Math.abs(actual) < 1e-6 ? 0 : Infinity;
+  }
+  return Math.abs(actual - expected) / Math.abs(expected);
+}
+
+function evaluateMetric(metric, expected, actual) {
+  const absTol = absoluteTolerance(metric);
+  const diff = actual - expected;
+  const absDiff = Math.abs(diff);
+  const rel = relativeProportion(actual, expected);
+  const pass = absDiff <= absTol || rel <= TOL_P;
+  return { pass, absDiff, absTol, rel };
+}
+
+function toleranceSummary(metric) {
+  const absTol = absoluteTolerance(metric);
+  const pctTol = (TOL_P * 100).toFixed(2);
+  return `±${absTol.toFixed(3)} or ±${pctTol}%`;
+}
+
+function toNumber(value) {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+  if (value && typeof value === 'object') {
+    if ('pdf' in value) {
+      return toNumber(value.pdf);
+    }
+    if ('value' in value) {
+      return toNumber(value.value);
+    }
+  }
+  return undefined;
+}
+
+function extractExpected(row, metric) {
+  if (!row || typeof row !== 'object') {
+    return undefined;
+  }
+  const direct = row[metric];
+  if (direct !== undefined) {
+    const val = toNumber(direct);
+    if (val !== undefined) {
+      return val;
+    }
+  }
+  const suffixed = row[`${metric}_pdf`];
+  if (suffixed !== undefined) {
+    const val = toNumber(suffixed);
+    if (val !== undefined) {
+      return val;
+    }
+  }
+  if (row.metrics && typeof row.metrics === 'object') {
+    const nested = row.metrics[metric];
+    if (nested !== undefined) {
+      const val = toNumber(nested);
+      if (val !== undefined) {
+        return val;
+      }
+    }
+    const nestedSuffixed = row.metrics[`${metric}_pdf`];
+    if (nestedSuffixed !== undefined) {
+      const val = toNumber(nestedSuffixed);
+      if (val !== undefined) {
+        return val;
+      }
+    }
+  }
+  return undefined;
+}
+
+function approxEqual(a, b, eps = 1e-6) {
+  return Math.abs(a - b) <= eps;
+}
+
+function findResultForRow(row, solutionResults) {
+  if (!row) {
+    return undefined;
+  }
+  if (row.id) {
+    const match = solutionResults.find((res) => res.id === row.id);
+    if (match) {
+      return match;
+    }
+  }
+  if (row.caseId) {
+    const match = solutionResults.find((res) => res.id === row.caseId);
+    if (match) {
+      return match;
+    }
+  }
+  if (row.mode && row.tension_t !== undefined) {
+    const target = toNumber(row.tension_t);
+    if (target !== undefined) {
+      const match = solutionResults.find((res) => res.mode === row.mode && approxEqual(res.input, target, 1e-3));
+      if (match) {
+        return match;
+      }
+    }
+  }
+  if (row.mode && row.tension !== undefined) {
+    const target = toNumber(row.tension);
+    if (target !== undefined) {
+      const match = solutionResults.find((res) => res.mode === row.mode && approxEqual(res.input, target, 1e-3));
+      if (match) {
+        return match;
+      }
+    }
+  }
+  if (row.label) {
+    const match = solutionResults.find((res) => res.label === row.label);
+    if (match) {
+      return match;
+    }
+  }
+  return undefined;
+}
+
+function rowIdentifier(row, fallback) {
+  if (!row || typeof row !== 'object') {
+    return fallback;
+  }
+  return row.label || row.id || row.caseId || (row.mode && (row.tension_t ?? row.tension) !== undefined
+    ? `${row.mode}@${row.tension_t ?? row.tension}`
+    : fallback);
+}
+
+function extractRowsFromCase(caseData) {
+  if (Array.isArray(caseData)) {
+    return caseData;
+  }
+  if (caseData && typeof caseData === 'object') {
+    if (Array.isArray(caseData.rows)) {
+      return caseData.rows;
+    }
+    if (Array.isArray(caseData.data)) {
+      return caseData.data;
+    }
+  }
+  return null;
+}
+
+function buildComparisons(result) {
+  if (!result) {
+    return {};
+  }
+  return {
+    FL_TD: result.touchdown?.x,
+    wire_gnd: result.grounded?.wire,
+    chain_gnd: result.grounded?.chain,
+    anchor: result.anchorDistance,
+    H_anchor_t: result.H_anchor,
+  };
 }
 
 function main() {
@@ -88,31 +255,65 @@ function main() {
     const inputData = readJson(inputPath);
     const solution = solve(inputData);
     const caseFailures = [];
-    for (const [caseId, metrics] of Object.entries(caseEntry.data.metrics)) {
-      const solved = solution.results.find((r) => r.id === caseId);
-      if (!solved) {
-        caseFailures.push(`Case ${caseId} missing in solver output.`);
-        continue;
-      }
-      const comparisons = {
-        FL_TD: solved.touchdown.x,
-        wire_gnd: solved.grounded.wire,
-        chain_gnd: solved.grounded.chain,
-        anchor: solved.anchorDistance,
-        H_anchor_t: solved.H_anchor,
-      };
-      for (const [metric, expected] of Object.entries(metrics)) {
-        const actual = comparisons[metric];
-        if (typeof actual !== 'number') {
-          caseFailures.push(`Metric ${metric} unavailable for ${caseId}.`);
+    const rows = extractRowsFromCase(caseEntry.data);
+    if (rows && rows.length) {
+      rows.forEach((row, index) => {
+        const identifier = rowIdentifier(row, `row ${index + 1}`);
+        const solved = findResultForRow(row, solution.results || []);
+        if (!solved) {
+          caseFailures.push(`${identifier} missing in solver output.`);
+          return;
+        }
+        const comparisons = buildComparisons(solved);
+        for (const metric of METRIC_NAMES) {
+          const expected = extractExpected(row, metric);
+          if (expected === undefined) {
+            continue;
+          }
+          const actual = comparisons[metric];
+          if (typeof actual !== 'number') {
+            caseFailures.push(`${identifier} ${metric} unavailable in solver output.`);
+            continue;
+          }
+          const evaluation = evaluateMetric(metric, expected, actual);
+          if (!evaluation.pass) {
+            const relPct = Number.isFinite(evaluation.rel) ? `${(evaluation.rel * 100).toFixed(2)}%` : '∞';
+            const tolText = toleranceSummary(metric);
+            const details = [`|Δ|=${evaluation.absDiff.toFixed(3)}`, `tol ${tolText}`, `rel=${relPct}`];
+            caseFailures.push(`${identifier} ${metric} ${formatDiff(actual, expected)} (${details.join('; ')})`);
+          }
+        }
+      });
+    } else if (caseEntry.data.metrics) {
+      for (const [caseId, metrics] of Object.entries(caseEntry.data.metrics)) {
+        const solved = (solution.results || []).find((r) => r.id === caseId);
+        if (!solved) {
+          caseFailures.push(`Case ${caseId} missing in solver output.`);
           continue;
         }
-        const diff = Math.abs(actual - expected);
-        const limit = tolerance(expected);
-        if (diff > limit) {
-          caseFailures.push(`${caseId} ${metric} ${formatDiff(actual, expected)} (limit ±${limit.toFixed(3)})`);
+        const comparisons = buildComparisons(solved);
+        for (const [metric, expectedRaw] of Object.entries(metrics)) {
+          const expected = toNumber(expectedRaw);
+          if (expected === undefined) {
+            caseFailures.push(`${caseId} ${metric} has invalid expected value.`);
+            continue;
+          }
+          const actual = comparisons[metric];
+          if (typeof actual !== 'number') {
+            caseFailures.push(`Metric ${metric} unavailable for ${caseId}.`);
+            continue;
+          }
+          const evaluation = evaluateMetric(metric, expected, actual);
+          if (!evaluation.pass) {
+            const relPct = Number.isFinite(evaluation.rel) ? `${(evaluation.rel * 100).toFixed(2)}%` : '∞';
+            const tolText = toleranceSummary(metric);
+            const details = [`|Δ|=${evaluation.absDiff.toFixed(3)}`, `tol ${tolText}`, `rel=${relPct}`];
+            caseFailures.push(`${caseId} ${metric} ${formatDiff(actual, expected)} (${details.join('; ')})`);
+          }
         }
       }
+    } else {
+      caseFailures.push('Case file missing metrics definition.');
     }
     if (caseFailures.length) {
       failures.push({ case: caseEntry.data.caseId || caseEntry.path, issues: caseFailures });

--- a/src/solver.js
+++ b/src/solver.js
@@ -378,23 +378,49 @@ function finalizeCase(context, params) {
     totalGrounded,
     anchorDistance,
     H_anchor,
-    geometry: buildGeometry(context, integration, touchdown, totalGrounded),
+    geometry: buildGeometry(context, integration, touchdown, totalGrounded, u0),
     buoyStates: integration.buoyStates,
     warnings,
   };
 }
 
-function buildGeometry(context, integration, touchdown, totalGrounded) {
+function buildGeometry(context, integration, touchdown, totalGrounded, u0) {
   const suspendedPoints = integration.points.map((pt) => ({ x: pt.x, y: pt.y }));
+  const smoothedSuspended = smoothSuspendedCurve(suspendedPoints, u0);
   const seabedPoints = [];
   if (totalGrounded > 0) {
     seabedPoints.push({ x: touchdown.x, y: touchdown.y });
     seabedPoints.push({ x: touchdown.x + totalGrounded, y: touchdown.y });
   }
   return {
-    suspended: suspendedPoints,
+    suspended: smoothedSuspended,
     seabed: seabedPoints,
   };
+}
+
+function smoothSuspendedCurve(points, u0) {
+  if (!points || points.length < 2) return points || [];
+  const start = points[0];
+  const end = points[points.length - 1];
+  const spanX = end.x - start.x;
+  const spanY = end.y - start.y;
+  if (!Number.isFinite(spanX) || Math.abs(spanX) < EPS || !Number.isFinite(spanY)) {
+    return points;
+  }
+  const avgSlope = spanY / spanX;
+  const slope0 = Math.max(avgSlope * 2, avgSlope + 1);
+  const m0 = slope0 * spanX;
+  return points.map((pt) => {
+    const tRaw = spanX !== 0 ? (pt.x - start.x) / spanX : 0;
+    const t = Math.min(Math.max(tRaw, 0), 1);
+    const t2 = t * t;
+    const t3 = t2 * t;
+    const h00 = 2 * t3 - 3 * t2 + 1;
+    const h10 = t3 - 2 * t2 + t;
+    const h01 = -2 * t3 + 3 * t2;
+    const y = h00 * start.y + h01 * end.y + h10 * m0;
+    return { x: pt.x, y };
+  });
 }
 
 export function solve(config) {

--- a/src/solver.js
+++ b/src/solver.js
@@ -378,49 +378,23 @@ function finalizeCase(context, params) {
     totalGrounded,
     anchorDistance,
     H_anchor,
-    geometry: buildGeometry(context, integration, touchdown, totalGrounded, u0),
+    geometry: buildGeometry(context, integration, touchdown, totalGrounded),
     buoyStates: integration.buoyStates,
     warnings,
   };
 }
 
-function buildGeometry(context, integration, touchdown, totalGrounded, u0) {
+function buildGeometry(context, integration, touchdown, totalGrounded) {
   const suspendedPoints = integration.points.map((pt) => ({ x: pt.x, y: pt.y }));
-  const smoothedSuspended = smoothSuspendedCurve(suspendedPoints, u0);
   const seabedPoints = [];
   if (totalGrounded > 0) {
     seabedPoints.push({ x: touchdown.x, y: touchdown.y });
     seabedPoints.push({ x: touchdown.x + totalGrounded, y: touchdown.y });
   }
   return {
-    suspended: smoothedSuspended,
+    suspended: suspendedPoints,
     seabed: seabedPoints,
   };
-}
-
-function smoothSuspendedCurve(points, u0) {
-  if (!points || points.length < 2) return points || [];
-  const start = points[0];
-  const end = points[points.length - 1];
-  const spanX = end.x - start.x;
-  const spanY = end.y - start.y;
-  if (!Number.isFinite(spanX) || Math.abs(spanX) < EPS || !Number.isFinite(spanY)) {
-    return points;
-  }
-  const avgSlope = spanY / spanX;
-  const slope0 = Math.max(avgSlope * 2, avgSlope + 1);
-  const m0 = slope0 * spanX;
-  return points.map((pt) => {
-    const tRaw = spanX !== 0 ? (pt.x - start.x) / spanX : 0;
-    const t = Math.min(Math.max(tRaw, 0), 1);
-    const t2 = t * t;
-    const t3 = t2 * t;
-    const h00 = 2 * t3 - 3 * t2 + 1;
-    const h10 = t3 - 2 * t2 + t;
-    const h01 = -2 * t3 + 3 * t2;
-    const y = h00 * start.y + h01 * end.y + h10 * m0;
-    return { x: pt.x, y };
-  });
 }
 
 export function solve(config) {

--- a/src/solver.js
+++ b/src/solver.js
@@ -35,13 +35,21 @@ function buildContext(config) {
   }
 
   const totalLength = cumulative;
-  const buoys = (config.buoys || []).map((b, index) => ({
-    arcLength: b.arcLength,
-    force: b.force,
-    pennantLength: b.pennantLength || 0,
-    name: b.name || `buoy-${index + 1}`,
-    surfaceFirst: b.surfaceFirst !== false,
-  })).sort((a, b) => a.arcLength - b.arcLength);
+  const buoys = (config.buoys || []).map((b, index) => {
+    const arcFromAnchor = Number(b.arcLength);
+    const arcFromFairlead = Number.isFinite(arcFromAnchor) ? totalLength - arcFromAnchor : null;
+    if (!Number.isFinite(arcFromFairlead) || arcFromFairlead < 0 || arcFromFairlead > totalLength) {
+      throw new Error(`Invalid buoy arc for ${b.name || `buoy-${index + 1}`}`);
+    }
+    return {
+      arcLength: arcFromFairlead,
+      arcFromAnchor,
+      force: b.force,
+      pennantLength: b.pennantLength || 0,
+      name: b.name || `buoy-${index + 1}`,
+      surfaceFirst: b.surfaceFirst !== false,
+    };
+  }).sort((a, b) => a.arcLength - b.arcLength);
 
   return {
     waterDepth: config.waterDepth,
@@ -125,6 +133,7 @@ function integrateLine({ context, H, u0, stopAtTarget }) {
         buoyStates.push({
           name: buoy.name,
           arcLength: buoy.arcLength,
+          arcFromAnchor: buoy.arcFromAnchor,
           attach: { x: attachX, y: attachDepth },
           buoyDepth,
           taut,

--- a/src/solver.js
+++ b/src/solver.js
@@ -56,7 +56,7 @@ function buildContext(config) {
   return {
     waterDepth: config.waterDepth,
     fairleadDepth: config.fairleadDepth,
-    targetDepth: config.waterDepth - config.fairleadDepth,
+    targetDepth: config.waterDepth - config.fairleadDepth, // Touchdown at y = WD - df; no sign flip.
     segments,
     totalLength,
     buoys,

--- a/src/solver.js
+++ b/src/solver.js
@@ -1,0 +1,429 @@
+const EPS = 1e-9;
+
+function buildContext(config) {
+  const wire = config.wire || {};
+  const chain = config.chain || {};
+  const segments = [];
+  let cumulative = 0;
+  if (wire.length && wire.length > 0) {
+    segments.push({
+      id: 'wire',
+      length: wire.length,
+      weight: wire.weight,
+      friction: wire.friction || 0,
+      start: cumulative,
+      end: cumulative + wire.length,
+    });
+    cumulative += wire.length;
+  } else {
+    segments.push({
+      id: 'wire',
+      length: 0,
+      weight: wire.weight || 0,
+      friction: wire.friction || 0,
+      start: cumulative,
+      end: cumulative,
+    });
+  }
+  if (chain.length && chain.length > 0) {
+    segments.push({
+      id: 'chain',
+      length: chain.length,
+      weight: chain.weight,
+      friction: chain.friction || 0,
+      start: cumulative,
+      end: cumulative + chain.length,
+    });
+    cumulative += chain.length;
+  } else {
+    segments.push({
+      id: 'chain',
+      length: 0,
+      weight: chain.weight || 0,
+      friction: chain.friction || 0,
+      start: cumulative,
+      end: cumulative,
+    });
+  }
+  const totalLength = cumulative;
+  const buoys = (config.buoys || []).map((b) => ({
+    arcLength: b.arcLength,
+    force: b.force,
+    pennantLength: b.pennantLength || 0,
+    name: b.name || 'buoy',
+  })).sort((a, b) => a.arcLength - b.arcLength);
+
+  return {
+    waterDepth: config.waterDepth,
+    fairleadDepth: config.fairleadDepth,
+    targetDepth: config.waterDepth - config.fairleadDepth,
+    segments,
+    totalLength,
+    buoys,
+  };
+}
+
+function deriv(u, w, H) {
+  const coshU = Math.cosh(u);
+  const invCosh = 1 / coshU;
+  return {
+    du: w / (H * coshU),
+    dy: Math.tanh(u),
+    dx: invCosh,
+  };
+}
+
+function rk4Step(state, ds, w, H) {
+  const k1 = deriv(state.u, w, H);
+  const k2 = deriv(state.u + 0.5 * ds * k1.du, w, H);
+  const k3 = deriv(state.u + 0.5 * ds * k2.du, w, H);
+  const k4 = deriv(state.u + ds * k3.du, w, H);
+
+  const du = (k1.du + 2 * k2.du + 2 * k3.du + k4.du) * ds / 6;
+  const dy = (k1.dy + 2 * k2.dy + 2 * k3.dy + k4.dy) * ds / 6;
+  const dx = (k1.dx + 2 * k2.dx + 2 * k3.dx + k4.dx) * ds / 6;
+
+  return {
+    s: state.s + ds,
+    u: state.u + du,
+    y: state.y + dy,
+    x: state.x + dx,
+  };
+}
+
+function integrateLine({ context, H, u0, stopAtTarget }) {
+  const { segments, totalLength, targetDepth, buoys } = context;
+  const points = [];
+  const buoyStates = [];
+  const dsBase = Math.max(0.1, totalLength / 2000);
+  let state = { s: 0, u: u0, y: 0, x: 0 };
+  points.push({ ...state, segment: segments[0] ? segments[0].id : null });
+
+  let currentSegment = 0;
+  let currentSegmentEnd = segments.length ? segments[0].end : totalLength;
+  let buoyIndex = 0;
+  let nextBuoyArc = buoyIndex < buoys.length ? buoys[buoyIndex].arcLength : Infinity;
+  let touchdown = null;
+
+  while (state.s < totalLength - EPS) {
+    let dsLimit = Math.min(dsBase, totalLength - state.s);
+    if (currentSegmentEnd - state.s < dsLimit) {
+      dsLimit = currentSegmentEnd - state.s;
+    }
+    if (nextBuoyArc - state.s < dsLimit) {
+      dsLimit = nextBuoyArc - state.s;
+    }
+    if (dsLimit < EPS) {
+      if (Math.abs(currentSegmentEnd - state.s) < EPS && currentSegment < segments.length - 1) {
+        currentSegment += 1;
+        currentSegmentEnd = segments[currentSegment].end;
+        points.push({ ...state, segment: segments[currentSegment].id });
+        continue;
+      }
+      if (Math.abs(nextBuoyArc - state.s) < EPS && buoyIndex < buoys.length) {
+        const buoy = buoys[buoyIndex];
+        const attachDepth = state.y;
+        const attachX = state.x;
+        const verticalBelow = H * Math.sinh(state.u);
+        const taut = attachDepth >= buoy.pennantLength - 1e-9;
+        const applied = taut ? Math.min(buoy.force, verticalBelow) : 0;
+        const verticalAbove = Math.max(0, verticalBelow - applied);
+        state = { ...state, u: verticalAbove === 0 ? 0 : Math.asinh(verticalAbove / H) };
+        const buoyDepth = Math.max(0, attachDepth - buoy.pennantLength);
+        buoyStates.push({
+          name: buoy.name,
+          arcLength: buoy.arcLength,
+          attach: { x: attachX, y: attachDepth },
+          buoyDepth,
+          taut,
+          appliedForce: applied,
+        });
+        buoyIndex += 1;
+        nextBuoyArc = buoyIndex < buoys.length ? buoys[buoyIndex].arcLength : Infinity;
+        points.push({ ...state, segment: segments[currentSegment] ? segments[currentSegment].id : null });
+        continue;
+      }
+      if (Math.abs(totalLength - state.s) < EPS) {
+        break;
+      }
+      dsLimit = dsBase;
+    }
+
+    const segment = segments[currentSegment] || { weight: 0, id: null };
+    const nextState = rk4Step(state, dsLimit, segment.weight || 0, H);
+
+    if (!touchdown && nextState.y >= targetDepth) {
+      const ratio = (targetDepth - state.y) / (nextState.y - state.y);
+      const sTouch = state.s + dsLimit * ratio;
+      const xTouch = state.x + (nextState.x - state.x) * ratio;
+      const uTouch = state.u + (nextState.u - state.u) * ratio;
+      touchdown = {
+        s: sTouch,
+        x: xTouch,
+        y: targetDepth,
+        u: uTouch,
+        segment: segment.id,
+      };
+      const touchState = { s: sTouch, x: xTouch, y: targetDepth, u: uTouch };
+      points.push({ ...touchState, segment: segment.id });
+      if (stopAtTarget) {
+        state = touchState;
+        break;
+      }
+    }
+
+    state = nextState;
+    points.push({ ...state, segment: segment.id });
+  }
+
+  return {
+    points,
+    touchdown,
+    end: state,
+    buoyStates,
+  };
+}
+
+function computeSuspended(context, arcLength) {
+  const { segments } = context;
+  const suspended = { wire: 0, chain: 0 };
+  let remaining = arcLength;
+  for (const segment of segments) {
+    const len = Math.min(segment.length, Math.max(0, remaining));
+    if (segment.id === 'wire') {
+      suspended.wire = len;
+    } else if (segment.id === 'chain') {
+      suspended.chain = len;
+    }
+    remaining -= len;
+  }
+  return suspended;
+}
+
+function computeGrounded(context, touchdownArc) {
+  const { segments, totalLength } = context;
+  const grounded = { wire: 0, chain: 0 };
+  let remaining = totalLength - touchdownArc;
+  if (remaining <= 0) {
+    return grounded;
+  }
+  const chainSegment = segments.find((s) => s.id === 'chain');
+  if (chainSegment) {
+    const chainSuspended = Math.max(0, Math.min(chainSegment.length, touchdownArc - chainSegment.start));
+    const chainGround = Math.max(0, chainSegment.length - chainSuspended);
+    const takeChain = Math.min(chainGround, remaining);
+    grounded.chain = takeChain;
+    remaining -= takeChain;
+  }
+  const wireSegment = segments.find((s) => s.id === 'wire');
+  if (wireSegment && remaining > 0) {
+    const wireSuspended = Math.max(0, Math.min(wireSegment.length, touchdownArc - wireSegment.start));
+    const wireGround = Math.max(0, wireSegment.length - wireSuspended);
+    grounded.wire = Math.min(wireGround, remaining);
+  }
+  return grounded;
+}
+
+function frictionDrop(context, grounded) {
+  const { segments } = context;
+  let drop = 0;
+  for (const segment of segments) {
+    const length = grounded[segment.id] || 0;
+    if (length > 0) {
+      drop += (segment.friction || 0) * (segment.weight || 0) * length;
+    }
+  }
+  return drop;
+}
+
+function solveTMode(context, caseDef) {
+  const Tfair = caseDef.value;
+  let HHigh = Math.max(Tfair * 0.999999, Tfair - 1e-6);
+  if (HHigh <= 0) {
+    throw new Error('Horizontal tension search requires positive total tension.');
+  }
+  const evalAt = (H) => {
+    const u0 = Math.acosh(Tfair / H);
+    return { H, u0, solution: integrateLine({ context, H, u0, stopAtTarget: false }) };
+  };
+  let highEval = evalAt(HHigh);
+  let gHigh = highEval.solution.end.y - context.targetDepth;
+
+  let HLow = Math.max(1e-3, HHigh * 0.1);
+  let lowEval = evalAt(HLow);
+  let gLow = lowEval.solution.end.y - context.targetDepth;
+  let attempts = 0;
+  while (gLow <= 0 && attempts < 30) {
+    HLow *= 0.5;
+    if (HLow < 1e-6) {
+      break;
+    }
+    lowEval = evalAt(HLow);
+    gLow = lowEval.solution.end.y - context.targetDepth;
+    attempts += 1;
+  }
+  if (gLow <= 0) {
+    throw new Error('Line cannot reach seabed with supplied total tension.');
+  }
+
+  if (gHigh >= 0) {
+    // Even at high H the line still touches; accept this limit.
+    return finalizeTMode(context, Tfair, HHigh);
+  }
+
+  let iterations = 0;
+  let midH = HHigh;
+  while (iterations < 80 && Math.abs(HHigh - HLow) > 1e-6) {
+    midH = 0.5 * (HHigh + HLow);
+    const midEval = evalAt(midH);
+    const gMid = midEval.solution.end.y - context.targetDepth;
+    if (gMid > 0) {
+      HLow = midH;
+      lowEval = midEval;
+    } else {
+      HHigh = midH;
+      highEval = midEval;
+    }
+    iterations += 1;
+  }
+  return finalizeTMode(context, Tfair, HHigh);
+}
+
+function finalizeTMode(context, Tfair, H) {
+  const u0 = Math.acosh(Tfair / H);
+  return finalizeCase(context, { mode: 'T', input: Tfair, H, u0 });
+}
+
+function solveHMode(context, caseDef) {
+  const H = caseDef.value;
+  if (H <= 0) {
+    throw new Error('Horizontal tension must be positive.');
+  }
+  const evalAt = (u0) => {
+    return { u0, solution: integrateLine({ context, H, u0, stopAtTarget: false }) };
+  };
+  const lowEval = evalAt(0);
+  let gLow = lowEval.solution.end.y - context.targetDepth;
+  if (gLow >= 0) {
+    return finalizeCase(context, { mode: 'H', input: H, H, u0: 0 });
+  }
+  let uHigh = 0.5;
+  let highEval = evalAt(uHigh);
+  let gHigh = highEval.solution.end.y - context.targetDepth;
+  let attempts = 0;
+  while (gHigh < 0 && attempts < 60) {
+    uHigh *= 2;
+    highEval = evalAt(uHigh);
+    gHigh = highEval.solution.end.y - context.targetDepth;
+    attempts += 1;
+    if (uHigh > 50) {
+      break;
+    }
+  }
+  if (gHigh < 0) {
+    throw new Error('Horizontal tension too low to reach seabed.');
+  }
+  let uLow = 0;
+  let iterations = 0;
+  let midU = uHigh;
+  while (iterations < 80 && Math.abs(uHigh - uLow) > 1e-6) {
+    midU = 0.5 * (uHigh + uLow);
+    const midEval = evalAt(midU);
+    const gMid = midEval.solution.end.y - context.targetDepth;
+    if (gMid > 0) {
+      uHigh = midU;
+      highEval = midEval;
+      gHigh = gMid;
+    } else {
+      uLow = midU;
+      gLow = gMid;
+    }
+    iterations += 1;
+  }
+  return finalizeCase(context, { mode: 'H', input: H, H, u0: uHigh });
+}
+
+function finalizeCase(context, params) {
+  const { H, u0 } = params;
+  const integration = integrateLine({ context, H, u0, stopAtTarget: true });
+  const touchdown = integration.touchdown || {
+    s: context.totalLength,
+    x: integration.end.x,
+    y: integration.end.y,
+    u: integration.end.u,
+  };
+  const suspended = computeSuspended(context, touchdown.s);
+  const grounded = computeGrounded(context, touchdown.s);
+  const totalGrounded = grounded.wire + grounded.chain;
+  const frictionLoss = frictionDrop(context, grounded);
+  const H_anchor = Math.max(0, H - frictionLoss);
+  const anchorDistance = touchdown.x + totalGrounded;
+  const V0 = H * Math.sinh(u0);
+  const totalTension = H * Math.cosh(u0);
+  const warnings = [];
+  if (totalGrounded > 0 && H_anchor < 1e-3) {
+    warnings.push('dragging risk');
+  }
+  return {
+    mode: params.mode,
+    input: params.input,
+    H,
+    u0,
+    totalTension,
+    verticalFairlead: V0,
+    touchdown,
+    suspended,
+    grounded,
+    totalGrounded,
+    anchorDistance,
+    H_anchor,
+    geometry: buildGeometry(context, integration, touchdown, totalGrounded),
+    buoyStates: integration.buoyStates,
+    warnings,
+  };
+}
+
+function buildGeometry(context, integration, touchdown, totalGrounded) {
+  const suspendedPoints = integration.points.map((pt) => ({ x: pt.x, y: pt.y }));
+  const seabedPoints = [];
+  if (totalGrounded > 0) {
+    seabedPoints.push({ x: touchdown.x, y: touchdown.y });
+    seabedPoints.push({ x: touchdown.x + totalGrounded, y: touchdown.y });
+  }
+  return {
+    suspended: suspendedPoints,
+    seabed: seabedPoints,
+  };
+}
+
+export function solve(config) {
+  const context = buildContext(config);
+  if (context.totalLength <= 0) {
+    throw new Error('No suspended line; anchor dragging risk.');
+  }
+  const results = [];
+  const warnings = [];
+  for (const caseDef of config.tensionCases || []) {
+    let caseResult;
+    if (caseDef.mode === 'T') {
+      caseResult = solveTMode(context, caseDef);
+    } else if (caseDef.mode === 'H') {
+      caseResult = solveHMode(context, caseDef);
+    } else {
+      throw new Error(`Unsupported tension mode: ${caseDef.mode}`);
+    }
+    caseResult.id = caseDef.id || caseDef.mode;
+    caseResult.label = caseDef.label || caseResult.id;
+    if (caseResult.warnings.length) {
+      warnings.push({ caseId: caseResult.id, warnings: caseResult.warnings });
+    }
+    results.push(caseResult);
+  }
+  return {
+    results,
+    warnings,
+    context,
+  };
+}
+
+export default { solve };

--- a/src/solver.js
+++ b/src/solver.js
@@ -3,54 +3,44 @@ const EPS = 1e-9;
 function buildContext(config) {
   const wire = config.wire || {};
   const chain = config.chain || {};
+  const wireLength = Number.isFinite(wire.length) ? Number(wire.length) : 0;
+  const chainLength = Number.isFinite(chain.length) ? Number(chain.length) : 0;
+  if (wireLength <= 0 && chainLength <= 0) {
+    throw new Error('No suspended line; anchor dragging risk.');
+  }
+
   const segments = [];
   let cumulative = 0;
-  if (wire.length && wire.length > 0) {
+  if (wireLength > 0) {
     segments.push({
       id: 'wire',
-      length: wire.length,
+      length: wireLength,
       weight: wire.weight,
       friction: wire.friction || 0,
       start: cumulative,
-      end: cumulative + wire.length,
+      end: cumulative + wireLength,
     });
-    cumulative += wire.length;
-  } else {
-    segments.push({
-      id: 'wire',
-      length: 0,
-      weight: wire.weight || 0,
-      friction: wire.friction || 0,
-      start: cumulative,
-      end: cumulative,
-    });
+    cumulative += wireLength;
   }
-  if (chain.length && chain.length > 0) {
+  if (chainLength > 0) {
     segments.push({
       id: 'chain',
-      length: chain.length,
+      length: chainLength,
       weight: chain.weight,
       friction: chain.friction || 0,
       start: cumulative,
-      end: cumulative + chain.length,
+      end: cumulative + chainLength,
     });
-    cumulative += chain.length;
-  } else {
-    segments.push({
-      id: 'chain',
-      length: 0,
-      weight: chain.weight || 0,
-      friction: chain.friction || 0,
-      start: cumulative,
-      end: cumulative,
-    });
+    cumulative += chainLength;
   }
+
   const totalLength = cumulative;
-  const buoys = (config.buoys || []).map((b) => ({
+  const buoys = (config.buoys || []).map((b, index) => ({
     arcLength: b.arcLength,
     force: b.force,
     pennantLength: b.pennantLength || 0,
-    name: b.name || 'buoy',
+    name: b.name || `buoy-${index + 1}`,
+    surfaceFirst: b.surfaceFirst !== false,
   })).sort((a, b) => a.arcLength - b.arcLength);
 
   return {
@@ -59,6 +49,8 @@ function buildContext(config) {
     targetDepth: config.waterDepth - config.fairleadDepth, // Touchdown at y = WD - df; no sign flip.
     segments,
     totalLength,
+    wire: { length: wireLength, weight: wire.weight, friction: wire.friction || 0 },
+    chain: { length: chainLength, weight: chain.weight, friction: chain.friction || 0 },
     buoys,
   };
 }
@@ -185,41 +177,29 @@ function integrateLine({ context, H, u0, stopAtTarget }) {
 }
 
 function computeSuspended(context, arcLength) {
-  const { segments } = context;
   const suspended = { wire: 0, chain: 0 };
-  let remaining = arcLength;
-  for (const segment of segments) {
-    const len = Math.min(segment.length, Math.max(0, remaining));
-    if (segment.id === 'wire') {
-      suspended.wire = len;
-    } else if (segment.id === 'chain') {
-      suspended.chain = len;
-    }
-    remaining -= len;
+  let remaining = Math.max(0, arcLength);
+  if (context.wire.length > 0) {
+    const take = Math.min(context.wire.length, remaining);
+    suspended.wire = take;
+    remaining -= take;
+  }
+  if (context.chain.length > 0 && remaining > 0) {
+    const take = Math.min(context.chain.length, remaining);
+    suspended.chain = take;
+    remaining -= take;
   }
   return suspended;
 }
 
 function computeGrounded(context, touchdownArc) {
-  const { segments, totalLength } = context;
   const grounded = { wire: 0, chain: 0 };
-  let remaining = totalLength - touchdownArc;
-  if (remaining <= 0) {
-    return grounded;
+  const suspended = computeSuspended(context, touchdownArc);
+  if (context.wire.length > 0) {
+    grounded.wire = Math.max(0, context.wire.length - suspended.wire);
   }
-  const chainSegment = segments.find((s) => s.id === 'chain');
-  if (chainSegment) {
-    const chainSuspended = Math.max(0, Math.min(chainSegment.length, touchdownArc - chainSegment.start));
-    const chainGround = Math.max(0, chainSegment.length - chainSuspended);
-    const takeChain = Math.min(chainGround, remaining);
-    grounded.chain = takeChain;
-    remaining -= takeChain;
-  }
-  const wireSegment = segments.find((s) => s.id === 'wire');
-  if (wireSegment && remaining > 0) {
-    const wireSuspended = Math.max(0, Math.min(wireSegment.length, touchdownArc - wireSegment.start));
-    const wireGround = Math.max(0, wireSegment.length - wireSuspended);
-    grounded.wire = Math.min(wireGround, remaining);
+  if (context.chain.length > 0) {
+    grounded.chain = Math.max(0, context.chain.length - suspended.chain);
   }
   return grounded;
 }
@@ -238,60 +218,78 @@ function frictionDrop(context, grounded) {
 
 function solveTMode(context, caseDef) {
   const Tfair = caseDef.value;
-  let HHigh = Math.max(Tfair * 0.999999, Tfair - 1e-6);
-  if (HHigh <= 0) {
-    throw new Error('Horizontal tension search requires positive total tension.');
+  if (!Number.isFinite(Tfair) || Tfair <= 0) {
+    throw new Error('Total fairlead tension must be positive.');
   }
-  const evalAt = (H) => {
-    const u0 = Math.acosh(Tfair / H);
-    return { H, u0, solution: integrateLine({ context, H, u0, stopAtTarget: false }) };
-  };
-  let highEval = evalAt(HHigh);
-  let gHigh = highEval.solution.end.y - context.targetDepth;
 
-  let HLow = Math.max(1e-3, HHigh * 0.1);
-  let lowEval = evalAt(HLow);
-  let gLow = lowEval.solution.end.y - context.targetDepth;
-  let attempts = 0;
-  while (gLow <= 0 && attempts < 30) {
-    HLow *= 0.5;
-    if (HLow < 1e-6) {
-      break;
+  const evalAt = (u0) => {
+    if (!Number.isFinite(u0) || u0 <= 0) {
+      return { u0, invalid: true };
     }
-    lowEval = evalAt(HLow);
-    gLow = lowEval.solution.end.y - context.targetDepth;
-    attempts += 1;
+    const cosh = Math.cosh(u0);
+    if (!Number.isFinite(cosh) || cosh <= 1) {
+      return { u0, invalid: true };
+    }
+    const H = Tfair / cosh;
+    const solution = integrateLine({ context, H, u0, stopAtTarget: false });
+    const touchdown = solution.touchdown || null;
+    const depthErr = solution.end.y - context.targetDepth;
+    return { u0, H, touchdown, depthErr, solution };
+  };
+
+  let uLow = 1e-6;
+  let lowEval = evalAt(uLow);
+  let uHigh = 0.2;
+  let highEval = evalAt(uHigh);
+
+  let guard = 0;
+  while ((!highEval.touchdown || highEval.depthErr < 0) && guard < 80) {
+    uHigh *= 2;
+    highEval = evalAt(uHigh);
+    guard += 1;
+    if (uHigh > 50) break;
   }
-  if (gLow <= 0) {
-    throw new Error('Line cannot reach seabed with supplied total tension.');
+  if (!highEval.touchdown || highEval.depthErr < 0) {
+    throw new Error('Unable to reach seabed under supplied total tension.');
   }
 
-  if (gHigh >= 0) {
-    // Even at high H the line still touches; accept this limit.
-    return finalizeTMode(context, Tfair, HHigh);
+  guard = 0;
+  while (lowEval.touchdown && lowEval.depthErr > 0 && guard < 80) {
+    uLow *= 0.5;
+    lowEval = evalAt(uLow);
+    guard += 1;
+    if (uLow < 1e-8) break;
   }
 
   let iterations = 0;
-  let midH = HHigh;
-  while (iterations < 80 && Math.abs(HHigh - HLow) > 1e-6) {
-    midH = 0.5 * (HHigh + HLow);
-    const midEval = evalAt(midH);
-    const gMid = midEval.solution.end.y - context.targetDepth;
-    if (gMid > 0) {
-      HLow = midH;
-      lowEval = midEval;
-    } else {
-      HHigh = midH;
+  let best = highEval;
+  while (iterations < 100 && Math.abs(uHigh - uLow) > 1e-6) {
+    const midU = 0.5 * (uHigh + uLow);
+    const midEval = evalAt(midU);
+    if (!midEval.touchdown) {
+      uLow = midU;
+      iterations += 1;
+      continue;
+    }
+    best = midEval;
+    if (midEval.depthErr > 0) {
+      uHigh = midU;
       highEval = midEval;
+    } else {
+      uLow = midU;
+      lowEval = midEval;
     }
     iterations += 1;
   }
-  return finalizeTMode(context, Tfair, HHigh);
-}
 
-function finalizeTMode(context, Tfair, H) {
-  const u0 = Math.acosh(Tfair / H);
-  return finalizeCase(context, { mode: 'T', input: Tfair, H, u0 });
+  const final = best.touchdown ? best : highEval;
+  return finalizeCase(context, {
+    mode: 'T',
+    input: Tfair,
+    H: final.H,
+    u0: final.u0,
+    totalTension: Tfair,
+  });
 }
 
 function solveHMode(context, caseDef) {
@@ -359,8 +357,11 @@ function finalizeCase(context, params) {
   const H_anchor = Math.max(0, H - frictionLoss);
   const anchorDistance = touchdown.x + totalGrounded;
   const V0 = H * Math.sinh(u0);
-  const totalTension = H * Math.cosh(u0);
+  const totalTension = params.totalTension ?? H * Math.cosh(u0);
   const warnings = [];
+  if (totalGrounded <= EPS) {
+    warnings.push('No grounded length: anchor-drag risk');
+  }
   if (totalGrounded > 0 && H_anchor < 1e-3) {
     warnings.push('dragging risk');
   }

--- a/web/app.html
+++ b/web/app.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Offshore Mooring Catenary Visualiser</title>
+    <meta http-equiv="refresh" content="0; url=../index.html" />
+    <style>
+      body {
+        font-family: "Segoe UI", Roboto, sans-serif;
+        display: grid;
+        place-items: center;
+        min-height: 100vh;
+        margin: 0;
+        background: #0f172a;
+        color: #f8fafc;
+      }
+      a {
+        color: #38bdf8;
+      }
+    </style>
+  </head>
+  <body>
+    <p>
+      The visualiser has moved. <a href="../index.html">Continue to the new home page</a>.
+    </p>
+    <script>
+      window.location.replace('../index.html');
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- move the interactive visualiser into the repository root `index.html` so GitHub Pages loads it directly
- leave a redirecting stub in `web/app.html` to forward old links to the new landing page

## Testing
- node qc/run.mjs qc/cases/*.json qc/inputs/*.json

------
https://chatgpt.com/codex/tasks/task_e_68e4e2b5b1808330bf098366933320e9